### PR TITLE
Fix time picker and number keypad preference being swapped

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
@@ -83,7 +83,7 @@ fun TimerScreen(timerModel: TimerModel) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                if (!useOldPicker) {
+                if (useOldPicker) {
                     Column(
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
A recent commit (maybe 5738f899bf77df8781d3370b77b1feba00955e0b) caused the "Minimal timer duration picker" to be on by default and the settings being swapped (switching it on turns it off). Quick fix.