### PR TITLE
fix: time picker input after disabling minimal time picker

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/nav/NavHost.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/nav/NavHost.kt
@@ -40,7 +40,7 @@ fun AppNavHost(
             StopwatchScreen(stopwatchModel)
         }
         composable(NavRoutes.Settings.route) {
-            SettingsScreen(settingsModel)
+            SettingsScreen(settingsModel, timerModel)
         }
     }
 }

--- a/app/src/main/java/com/bnyro/clock/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/SettingsScreen.kt
@@ -11,13 +11,16 @@ import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bnyro.clock.BuildConfig
 import com.bnyro.clock.R
+import com.bnyro.clock.ui.model.INITIAL_SECONDS_STATE
 import com.bnyro.clock.ui.model.SettingsModel
+import com.bnyro.clock.ui.model.TimerModel
 import com.bnyro.clock.ui.prefs.ButtonGroupPref
 import com.bnyro.clock.ui.prefs.IconPreference
 import com.bnyro.clock.ui.prefs.SettingsCategory
@@ -27,7 +30,8 @@ import com.bnyro.clock.util.Preferences
 
 @Composable
 fun SettingsScreen(
-    settingsModel: SettingsModel
+    settingsModel: SettingsModel,
+    timerModel: TimerModel
 ) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current
@@ -64,7 +68,10 @@ fun SettingsScreen(
             prefKey = Preferences.timerUsePickerKey,
             title = stringResource(R.string.timer_use_time_picker),
             defaultValue = false
-        )
+        ) {
+            // reset the timer model state to prevent issues when changing the time picker layout
+            timerModel.timePickerSecondsState = INITIAL_SECONDS_STATE
+        }
         SwitchPref(
             prefKey = Preferences.timerShowExamplesKey,
             title = stringResource(R.string.show_timer_quick_selection),


### PR DESCRIPTION
We're now just resetting the time picker to its initial state when the preference changed.

closes #135