### PR TITLE
Timer card tweaks

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/components/TimerItem.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/components/TimerItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -16,7 +15,7 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -46,7 +45,6 @@ fun TimerItem(obj: ScheduledObject, index: Int, timerModel: TimerModel) {
     val context = LocalContext.current
     val minutes = obj.currentPosition.value / 60000
     val seconds = (obj.currentPosition.value % 60000) / 1000
-    val hundreds = obj.currentPosition.value % 1000 / 10
 
     var showLabelEditor by remember {
         mutableStateOf(false)
@@ -80,11 +78,7 @@ fun TimerItem(obj: ScheduledObject, index: Int, timerModel: TimerModel) {
                     ) {
                         Text(
                             text = "$minutes:${seconds.addZero()}",
-                            style = MaterialTheme.typography.headlineMedium
-                        )
-                        Spacer(modifier = Modifier.width(5.dp))
-                        Text(
-                            text = hundreds.addZero()
+                            style = MaterialTheme.typography.displaySmall
                         )
                     }
                 }
@@ -98,13 +92,15 @@ fun TimerItem(obj: ScheduledObject, index: Int, timerModel: TimerModel) {
                 ClickableIcon(imageVector = Icons.Default.Close) {
                     timerModel.stopTimer(context, index)
                 }
-                FloatingActionButton(onClick = {
-                    when (obj.state.value) {
-                        WatchState.PAUSED -> timerModel.resumeTimer(index)
-                        WatchState.RUNNING -> timerModel.pauseTimer(index)
-                        else -> timerModel.startTimer(context)
+                FilledIconButton(
+                    onClick = {
+                        when (obj.state.value) {
+                            WatchState.PAUSED -> timerModel.resumeTimer(index)
+                            WatchState.RUNNING -> timerModel.pauseTimer(index)
+                            else -> timerModel.startTimer(context)
+                        }
                     }
-                }) {
+                ){
                     Icon(
                         imageVector = if (obj.state.value == WatchState.RUNNING) {
                             Icons.Default.Pause
@@ -116,7 +112,9 @@ fun TimerItem(obj: ScheduledObject, index: Int, timerModel: TimerModel) {
                 }
             }
             LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth().padding(8.dp).height(10.dp),
+                modifier = Modifier.fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .height(8.dp),
                 progress = obj.currentPosition.value / obj.initialPosition.toFloat(),
                 strokeCap = StrokeCap.Round
             )


### PR DESCRIPTION
Some small tweaks to the timer card. The FAB should only be used for the primary action and only at the bottom of the screen, so I replaced it with a FilledIconButton which looks great here. I also increased the timer font size and removed the milliseconds. They only make sense in the stopwatch tab IMO and make the UI more busy. Also did some minor padding tweaks.

Before:
![signal-2023-09-10-17-08-59-535](https://github.com/you-apps/ClockYou/assets/82398591/01837612-a8a9-4c5f-a63d-8d4d9450b5f8)


After:
![signal-2023-09-10-17-09-12-782](https://github.com/you-apps/ClockYou/assets/82398591/92451ed0-4d72-4ec6-98a5-109c5d6fd3a5)

Some more ideas to improve the timer card would be to 
1. replace the delete button by swipe to dismiss
2. hide the label and sound icons by animated visibility like in the alarm card, since I think they're rarely used and the UI could be more minimal that way

I'm interested in your opinion on that.