### PR TITLE
Migrated Room DB from Kapt to Ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,12 +20,8 @@ android {
             useSupportLibrary = true
         }
 
-        javaCompileOptions {
-            annotationProcessorOptions {
-                compilerArgumentProviders(
-                        RoomSchemaArgProvider(File(projectDir, "schemas"))
-                )
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -99,7 +99,7 @@ dependencies {
 
 
     //Room DB
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.library) apply false
+    alias(libs.plugins.ksp) apply false
 
 }
 true // Needed to make the Suppress annotation work for the plugins block

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycle-runtime-ktx = "2.6.1"
 activity-compose = "1.7.2"
 compose-bom = "2023.06.00"
 library = "8.0.1"
+ksp = "1.8.10-1.0.9"
 material = "1.9.0"
 navigation-compose = "2.5.3"
 material-icons-extended = "1.4.3"
@@ -56,3 +57,4 @@ room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room"}
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 library = { id = "com.android.library", version.ref = "library" }
+ksp = {id = "com.google.devtools.ksp", version.ref = "ksp"}


### PR DESCRIPTION
# What's changed?

- Migrate Room to KSP
- Get rid of KAPT entirely
- The project to build faster and still work properly

Closes issue #170 