### PR TITLE
style: fullscreen alarm improvements

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/screens/AlarmAlertScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/AlarmAlertScreen.kt
@@ -21,13 +21,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AlarmOff
 import androidx.compose.material.icons.rounded.Snooze
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -99,7 +100,11 @@ fun AlarmAlertScreen(onDismiss: () -> Unit, onSnooze: () -> Unit, label: String?
                         }
                     ) {
                         Row(Modifier.padding(8.dp)) {
-                            Icon(imageVector = Icons.Rounded.Snooze, contentDescription = null)
+                            Icon(
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                                imageVector = Icons.Rounded.Snooze,
+                                contentDescription = null
+                            )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = stringResource(R.string.snooze),
@@ -107,15 +112,23 @@ fun AlarmAlertScreen(onDismiss: () -> Unit, onSnooze: () -> Unit, label: String?
                             )
                         }
                     }
-                    TextButton(
+                    Button(
                         onClick = {
                             onDismiss.invoke()
                         }
                     ) {
-                        Text(
-                            text = stringResource(R.string.dismiss),
-                            style = MaterialTheme.typography.titleLarge
-                        )
+                        Row(Modifier.padding(8.dp)) {
+                            Icon(
+                                modifier = Modifier.align(alignment = Alignment.CenterVertically),
+                                imageVector = Icons.Rounded.AlarmOff,
+                                contentDescription = null
+                                )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.dismiss),
+                                style = MaterialTheme.typography.titleLarge
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In this PR:
- use default button for dismiss (since it's the primary action)
- make dismiss button larger 
- add icon to dismiss button
- fix snooze icon not centered vertically 

![Fix](https://github.com/you-apps/ClockYou/assets/82398591/18237041-0155-4f60-afa6-4154f2e46bfe)

| Before | After |
| --- | --- |
| ![Before](https://github.com/you-apps/ClockYou/assets/82398591/fe4d2fe2-7bff-4c9d-a03f-1b232af3f264) | ![After](https://github.com/you-apps/ClockYou/assets/82398591/52bd35eb-0453-42fb-9817-ed6b49334bda) |
