### PR TITLE
chore: add Yangon to tz_data.json

### DIFF
--- a/app/src/main/assets/tz_data.json
+++ b/app/src/main/assets/tz_data.json
@@ -1290,6 +1290,12 @@
     "zoneName": "Maputo"
   },
   {
+    "countryName": "Myanmar (မြန်မာ)",
+    "countryCode": "MM",
+    "zoneId": "Asia/Yangon",
+    "zoneName": "Yangon"
+  },
+  {
     "countryName": "Namibia (Namibië)",
     "countryCode": "NA",
     "zoneId": "Africa/Windhoek",


### PR DESCRIPTION
Adding Yangon, Myanmar to time zone database, as their are no Burmese cities as of yet