### PR TITLE
fix: improved stopwatch service and notification

### DIFF
--- a/app/src/main/java/com/bnyro/clock/services/StopwatchService.kt
+++ b/app/src/main/java/com/bnyro/clock/services/StopwatchService.kt
@@ -1,45 +1,210 @@
 package com.bnyro.clock.services
 
-import androidx.compose.runtime.mutableStateOf
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.Binder
+import android.os.Build
+import android.util.Log
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.bnyro.clock.R
-import com.bnyro.clock.obj.ScheduledObject
 import com.bnyro.clock.obj.WatchState
+import com.bnyro.clock.ui.MainActivity
 import com.bnyro.clock.util.NotificationHelper
+import java.util.Timer
+import java.util.TimerTask
 
-class StopwatchService : ScheduleService() {
-    override val notificationId = 1
+class StopwatchService : Service() {
+    private val notificationId = 1
+    var currentPosition = 0
+        private set
+    var state = WatchState.IDLE
+        private set
 
-    override fun onCreate() {
-        super.onCreate()
-        scheduledObjects.add(
-            ScheduledObject(
-                state = mutableStateOf(WatchState.RUNNING),
-                id = notificationId
-            )
-        )
-    }
+    private val timer = Timer()
 
-    override fun updateState() {
-        scheduledObjects.forEach {
-            if (it.state.value == WatchState.RUNNING) {
-                it.currentPosition.value += updateDelay
-                invokeChangeListener()
+    private lateinit var contentIntent: PendingIntent
+    private lateinit var notificationManager: NotificationManagerCompat
+    private var notificationPermission = true
+
+    var onPositionChange: (Int) -> Unit = {}
+    var onStateChange: (WatchState) -> Unit = {}
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val extra = intent.getStringExtra(ACTION_EXTRA_KEY)
+            Log.d("Stopwatch Actions", extra.toString())
+            when (extra) {
+                ACTION_START -> start()
+                ACTION_STOP -> stop()
+                ACTION_PAUSE_RESUME -> {
+                    if (state == WatchState.PAUSED) resume() else pause()
+                }
             }
         }
     }
 
-    override fun getNotification(scheduledObject: ScheduledObject) = NotificationCompat.Builder(
-        this,
-        NotificationHelper.STOPWATCH_CHANNEL
-    )
-        .setContentTitle(getText(R.string.stopwatch))
-        .setUsesChronometer(scheduledObject.state.value == WatchState.RUNNING)
-        .setWhen(System.currentTimeMillis() - scheduledObject.currentPosition.value)
-        .addAction(stopAction(scheduledObject))
-        .addAction(pauseResumeAction(scheduledObject))
-        .setSmallIcon(R.drawable.ic_notification)
-        .build()
+    override fun onCreate() {
+        super.onCreate()
+        notificationManager = NotificationManagerCompat.from(this)
 
-    override fun getStartNotification() = getNotification(ScheduledObject())
+        contentIntent = PendingIntent.getActivity(
+            this,
+            8,
+            Intent(this, MainActivity::class.java).setAction(MainActivity.SHOW_STOPWATCH_ACTION),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationPermission = ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            registerReceiver(receiver, IntentFilter(STOPWATCH_INTENT_ACTION), RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(receiver, IntentFilter(STOPWATCH_INTENT_ACTION))
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(receiver)
+        counterTask?.cancel()
+        counterTask = null
+        timer.cancel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(notificationId, getNotification())
+        return START_STICKY
+    }
+
+    private var counterTask: TimerTask? = null
+
+    private fun start() {
+        currentPosition = 0
+        updateState(WatchState.RUNNING)
+        counterTask = object : TimerTask() {
+            override fun run() {
+                if (state != WatchState.PAUSED) {
+                    currentPosition += UPDATE_DELAY
+                    onPositionChange(currentPosition)
+                }
+            }
+        }
+        timer.scheduleAtFixedRate(counterTask, 0, UPDATE_DELAY.toLong())
+    }
+
+    private fun stop() {
+        updateState(WatchState.IDLE)
+        notificationManager.cancel(notificationId)
+        currentPosition = 0
+        onPositionChange(currentPosition)
+        counterTask?.cancel()
+        counterTask = null
+        stopSelf()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun updateNotification() {
+        if (notificationPermission) {
+            notificationManager.notify(notificationId, getNotification())
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun getNotification(): Notification {
+        return NotificationCompat.Builder(
+            this,
+            NotificationHelper.STOPWATCH_CHANNEL
+        )
+            .setContentTitle(getText(R.string.stopwatch))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(contentIntent)
+            .apply {
+                if (state != WatchState.IDLE) {
+                    addAction(stopAction())
+                    addAction(pauseResumeAction())
+                }
+            }
+            .setUsesChronometer(state == WatchState.RUNNING)
+            .setWhen(System.currentTimeMillis() - currentPosition)
+            .build()
+    }
+
+    private fun pause() {
+        updateState(WatchState.PAUSED)
+    }
+
+    private fun resume() {
+        updateState(WatchState.RUNNING)
+    }
+
+    private fun updateState(newState: WatchState) {
+        state = newState
+        updateNotification()
+        onStateChange(newState)
+    }
+
+    private fun getAction(title: String, requestCode: Int, action: String) =
+        NotificationCompat.Action.Builder(
+            null,
+            title,
+            getPendingIntent(
+                Intent(STOPWATCH_INTENT_ACTION).putExtra(
+                    ACTION_EXTRA_KEY,
+                    action
+                ), requestCode
+            )
+        ).build()
+
+    private fun stopAction() =
+        getAction(getString(R.string.stop), STOP_ACTION_REQUEST_CODE, ACTION_STOP)
+
+    private fun pauseResumeAction(): NotificationCompat.Action {
+        val text =
+            if (state == WatchState.RUNNING) getString(R.string.pause) else getString(R.string.resume)
+        return getAction(
+            text,
+            PAUSE_RESUME_ACTION_REQUEST_CODE,
+            ACTION_PAUSE_RESUME
+        )
+    }
+
+    private fun getPendingIntent(intent: Intent, requestCode: Int): PendingIntent =
+        PendingIntent.getBroadcast(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+    private val binder = LocalBinder()
+    override fun onBind(intent: Intent) = binder
+
+    inner class LocalBinder : Binder() {
+        fun getService() = this@StopwatchService
+    }
+
+    companion object {
+        private const val UPDATE_DELAY = 10
+
+        const val STOPWATCH_INTENT_ACTION = "com.bnyro.clock.STOPWATCH_ACTION"
+        const val ACTION_EXTRA_KEY = "action"
+        const val ACTION_PAUSE_RESUME = "pause_resume"
+        const val ACTION_STOP = "stop"
+        const val ACTION_START = "start"
+
+        const val STOP_ACTION_REQUEST_CODE = 6
+        const val PAUSE_RESUME_ACTION_REQUEST_CODE = 7
+    }
 }

--- a/app/src/main/java/com/bnyro/clock/ui/model/StopwatchModel.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/model/StopwatchModel.kt
@@ -1,71 +1,51 @@
 package com.bnyro.clock.ui.model
 
-import android.annotation.SuppressLint
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
-import android.os.IBinder
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
-import com.bnyro.clock.obj.ScheduledObject
 import com.bnyro.clock.obj.WatchState
-import com.bnyro.clock.services.ScheduleService
 import com.bnyro.clock.services.StopwatchService
 
 class StopwatchModel : ViewModel() {
-    var scheduledObject by mutableStateOf(ScheduledObject())
     val rememberedTimeStamps = mutableStateListOf<Int>()
+    var currentPosition by mutableStateOf(0)
+    var state: WatchState by mutableStateOf(WatchState.IDLE)
 
-    @SuppressLint("StaticFieldLeak")
-    private var service: StopwatchService? = null
+    private fun startStopwatch(context: Context) {
+        val intent = Intent(context, StopwatchService::class.java)
+        ContextCompat.startForegroundService(context, intent)
 
-    private val serviceConnection = object : ServiceConnection {
-        override fun onServiceConnected(component: ComponentName, binder: IBinder) {
-            service = (binder as ScheduleService.LocalBinder).getService() as? StopwatchService
-            service?.changeListener = {
-                this@StopwatchModel.scheduledObject = it.firstOrNull() ?: ScheduledObject()
+        rememberedTimeStamps.clear()
+        val startIntent = Intent(StopwatchService.STOPWATCH_INTENT_ACTION).putExtra(
+            StopwatchService.ACTION_EXTRA_KEY,
+            StopwatchService.ACTION_START
+        )
+        context.sendBroadcast(startIntent)
+    }
+
+    fun pauseResumeStopwatch(context: Context) {
+        when (state) {
+            WatchState.IDLE -> startStopwatch(context)
+            else -> {
+                val pauseResumeIntent = Intent(StopwatchService.STOPWATCH_INTENT_ACTION).putExtra(
+                    StopwatchService.ACTION_EXTRA_KEY,
+                    StopwatchService.ACTION_PAUSE_RESUME
+                )
+                context.sendBroadcast(pauseResumeIntent)
             }
         }
-
-        override fun onServiceDisconnected(p0: ComponentName?) {
-            scheduledObject.state.value = WatchState.IDLE
-            service = null
-        }
-    }
-
-    fun startStopwatch(context: Context) {
-        rememberedTimeStamps.clear()
-        val intent = Intent(context, StopwatchService::class.java)
-        runCatching {
-            context.stopService(intent)
-        }
-        runCatching {
-            context.unbindService(serviceConnection)
-        }
-        ContextCompat.startForegroundService(context, intent)
-        context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
-    }
-
-    fun tryConnect(context: Context) {
-        val intent = Intent(context, StopwatchService::class.java)
-        context.bindService(intent, serviceConnection, Context.BIND_ABOVE_CLIENT)
-    }
-
-    fun pauseStopwatch() {
-        service?.pause(scheduledObject)
-    }
-
-    fun resumeStopwatch() {
-        service?.resume(scheduledObject)
     }
 
     fun stopStopwatch(context: Context) {
-        service?.stop(scheduledObject)
-        context.unbindService(serviceConnection)
+        val stopIntent = Intent(StopwatchService.STOPWATCH_INTENT_ACTION).putExtra(
+            StopwatchService.ACTION_EXTRA_KEY,
+            StopwatchService.ACTION_STOP
+        )
+        context.sendBroadcast(stopIntent)
     }
 }

--- a/app/src/main/java/com/bnyro/clock/util/PermissionHelper.kt
+++ b/app/src/main/java/com/bnyro/clock/util/PermissionHelper.kt
@@ -16,7 +16,7 @@ object PermissionHelper {
         return true
     }
 
-    private fun hasPermission(context: Context, permission: String): Boolean {
+    fun hasPermission(context: Context, permission: String): Boolean {
         return ActivityCompat.checkSelfPermission(
             context,
             permission


### PR DESCRIPTION
## Improvements
- Use a [bound service](https://developer.android.com/develop/background-work/services/bound-services) for stopwatch and move it to foreground only when a stopwatch is running [^1]
- Move the service connection logic into the MainActivity [^2]
- Use a simple integer value to store the stopwatch progress
- Click the notification to open stopwatch screen

[^1]: This should be more responsive than starting and stopping the service for every stopwatch run
[^2]: This prevents leaking a context object in the viewmodel

## Demo
| Old Behavior| New Behavior |
| --- | --- |
| <video src="https://github.com/you-apps/ClockYou/assets/64766434/ff06331c-4d5d-4907-ab27-48971c196962" width="100%"> | <video src="https://github.com/you-apps/ClockYou/assets/64766434/e9700764-e232-436f-bdd2-556d8a1e42b1" width="100%"> |

## Other tests
I started the stopwatch. Cleared the app from task view and waited for about a half an hour with the device screen turned off. The stopwatch service managed to survive that whole time without crashing.

<img src="https://github.com/you-apps/ClockYou/assets/64766434/f194ea2a-7bd8-459c-95e0-0d7633ca17f0" width="30%">
<img src="https://github.com/you-apps/ClockYou/assets/64766434/52e0be48-da5e-428e-a182-09bfecc23b1a" width="30%">

