### PR TITLE
Changed timer notificationChanneId to a static value

### DIFF
--- a/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
@@ -354,7 +354,7 @@ class TimerService : Service() {
         val ringtoneUri = timerObject.ringtone ?: RingtoneHelper().getDefault(this)
         val vibrationPattern = NotificationHelper.vibrationPattern.takeIf { timerObject.vibrate }
         val notificationChannelId =
-            NotificationHelper.TIMER_FINISHED_CHANNEL + "-" + System.currentTimeMillis()
+            NotificationHelper.TIMER_FINISHED_CHANNEL
         val notificationId = (Integer.MAX_VALUE / 3) + timerObject.id * 10
 
 


### PR DESCRIPTION
System notification categories are removed properly as the id is the same every time.

See [#448 ](https://github.com/you-apps/ClockYou/issues/448) for all details.