### PR TITLE
Add fullscreen permission check in onboarding and add a compatibility fix for Android 16+

### DIFF
--- a/app/src/main/java/com/bnyro/clock/domain/model/Permission.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/Permission.kt
@@ -3,10 +3,12 @@ package com.bnyro.clock.domain.model
 import android.Manifest
 import android.app.Activity
 import android.app.AlarmManager
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT
 import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -49,6 +51,28 @@ sealed class Permission(
             )
         }
     }
+
+    object FullScreenAlarmPermission : Permission(
+        titleRes = R.string.full_screen_alarm_permission_title,
+        descriptionRes = R.string.full_screen_alarm_permission_description,
+        iconRes = R.drawable.ic_alarm
+    ) {
+        override fun hasPermission(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return true
+            val notificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            return notificationManager.canUseFullScreenIntent()
+        }
+
+        override fun requestPermission(activity: Activity) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+            val intent = Intent(ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+                data = "package:${activity.packageName}".toUri()
+            }
+            activity.startActivity(intent)
+        }
+    }
+
     object BatteryOptimizationPermission : Permission(
         titleRes = R.string.battery_optimization_title,
         descriptionRes = R.string.battery_optimization_description,

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/permission/PermissionModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/permission/PermissionModel.kt
@@ -14,6 +14,7 @@ class PermissionModel(application: Application) :
         val allPermissions = listOf(
             Permission.AlarmPermission,
             Permission.NotificationPermission,
+            Permission.FullScreenAlarmPermission,
             Permission.BatteryOptimizationPermission,
             Permission.AllDonePermission
 

--- a/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
@@ -1,6 +1,7 @@
 package com.bnyro.clock.util.services
 
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -215,7 +216,22 @@ class AlarmService : Service() {
             this@AlarmService,
             0,
             alarmActivityIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                @Suppress("DEPRECATION")
+                val backgroundActivityStartMode =
+                    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                        ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOW_ALWAYS
+                    } else {
+                        ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+                    }
+                ActivityOptions.makeBasic().apply {
+                    pendingIntentCreatorBackgroundActivityStartMode =
+                        backgroundActivityStartMode
+                }.toBundle()
+            } else {
+                null
+            }
         )
 
         val dismissAlarmIntent = Intent(ALARM_INTENT_ACTION)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,8 @@
     <string name="all_done_description">Some manufacturers use their own background access permission</string>
     <string name="battery_optimization_title">Disable Battery Optimization</string>
     <string name="battery_optimization_description">This permission is needed for timers to work when the Phone Screen is off.</string>
+    <string name="full_screen_alarm_permission_title" tools:ignore="MissingTranslation">Full-screen alarms</string>
+    <string name="full_screen_alarm_permission_description" tools:ignore="MissingTranslation">Allow full-screen alarms so ringing alarms can appear over the lock screen.</string>
     <string name="available_days_0">S</string>
     <string name="available_days_1">M</string>
     <string name="available_days_2">T</string>


### PR DESCRIPTION
hi, so I used a Samsung device where it blocks the background launching, meaning it has to rely on this permission in order for the alarm to appear correctly when the screen is off/locked, which I've tested and it works.

the changes are quite straightforward, I just copied one of your onboarding screen and extend it for the fullscreen permission, but that alone isn't enough, because Samsung blocks direct background launch, the `startActivity()` path, while allowing Android’s full-screen `PendingIntent` path when its background-launch mode is configured correctly.

since my Samsung is running Android 16+, the ALLOWED constant used on Android 14-15 is deprecated in favor of the newer, more explicit modes, namely the ALWAYS_ALLOW. so I made a little change inside `app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt` file to support both.

I've done the testing on my side, which works. I hope you can consider my implementation.

<img width="838" height="1280" alt="image" src="https://github.com/user-attachments/assets/35cf18ad-4251-41ca-90de-38ec4f1aefaf" />


<img width="1280" height="534" alt="image" src="https://github.com/user-attachments/assets/d5ef2154-4e87-41fb-a2c3-7fe617ee5da0" />

_ignore the "Jay" that's just my build name_