### PR TITLE
[5/17] Restart existing timers instead of creating duplicate timers

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/TimerItem.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/TimerItem.kt
@@ -139,11 +139,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                     ) {
                         FilledIconButton(
                             modifier = Modifier.size(48.dp),
-                            onClick = {
-                                timerModel.stopTimer(context, obj.id)
-                                val originalSeconds = (obj.initialPosition / 1000).toInt()
-                                timerModel.startTimer(context, delay = originalSeconds)
-                            }
+                            onClick = { timerModel.restartTimer(context, obj.id) }
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Refresh,
@@ -175,9 +171,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                         }
 
                         ClickableIcon(imageVector = Icons.Default.Refresh) {
-                            timerModel.stopTimer(context, obj.id)
-                            val originalSeconds = (obj.initialPosition / 1000).toInt()
-                            timerModel.startTimer(context, delay = originalSeconds)
+                            timerModel.restartTimer(context, obj.id)
                         }
 
                         ClickableIcon(imageVector = Icons.Default.Close) {

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/model/TimerModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/model/TimerModel.kt
@@ -120,6 +120,19 @@ class TimerModel : ViewModel() {
         context.sendBroadcast(stopIntent)
     }
 
+    fun restartTimer(context: Context, index: Int) {
+        val restartIntent = Intent(TimerService.UPDATE_STATE_ACTION)
+            .putExtra(
+                TimerService.ID_EXTRA_KEY,
+                index
+            )
+            .putExtra(
+                TimerService.ACTION_EXTRA_KEY,
+                TimerService.TIMER_RESTART
+            )
+        context.sendBroadcast(restartIntent)
+    }
+
     /* =============== Numpad time picker ======================== */
     var timePickerFakeUnits by mutableStateOf(
         0,


### PR DESCRIPTION
the in-app reset buttons currently stop a timer and create an entirely new timer using its original duration.

because it creates a new timer, the reset path doesn't preserve the original `TimerObject`, including its ID, label, ringtone, and vibration setting. it can also result in duplicate timer behaviour rather than resetting the timer the user actually pressed.

this changes both in-app reset buttons to send the existing `TimerService.TIMER_RESTART` action, which is already the intended restart path used by the timer notification. the same timer object is now reset to its original duration while keeping its existing settings.

I'll attach a recording of a labelled timer being reset several times while remaining a single timer with the same label and options.