### PR TITLE
[4/17] Enable vibration by default for new alarms

### DIFF
--- a/app/src/main/java/com/bnyro/clock/domain/model/Alarm.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/Alarm.kt
@@ -18,7 +18,7 @@ data class Alarm(
     var label: String? = null,
     var enabled: Boolean = false,
     var days: List<Int> = listOf(0, 1, 2, 3, 4, 5, 6),
-    var vibrate: Boolean = false,
+    var vibrate: Boolean = true,
     var soundName: String? = null,
     var soundUri: String? = null,
     @ColumnInfo(defaultValue = "1") var repeat: Boolean = false,


### PR DESCRIPTION
this enables vibration by default when creating a new alarm, which matches the default behaviour used by most clock applications.

the change only affects the default value used for newly created alarms. existing alarms continue using their saved vibration setting.

I'll attach a screenshot of a newly opened alarm editor showing Vibrate enabled by default.