### PR TITLE
[7/17] Make wheel pickers reliably select the highlighted value

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/ScrollAlarmTimePicker.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/ScrollAlarmTimePicker.kt
@@ -2,6 +2,7 @@ package com.bnyro.clock.presentation.screens.alarm.components
 
 import android.text.format.DateFormat
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.SnapPosition
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +20,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -100,20 +103,25 @@ fun MeridiemPicker(
 ) {
     val primary = MaterialTheme.colorScheme.primary
     val primaryMuted = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-    val state = rememberPagerState(initialPage = 200 + value.ordinal + 1) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val state = rememberPagerState(initialPage = 200 + value.ordinal) {
         400
     }
-    val currentPage = state.currentPage + 1
+    val currentPage = state.currentPage
 
     LaunchedEffect(currentPage) {
         onValueChanged(Meridiem.entries[currentPage % 2])
+        if (state.isScrollInProgress) {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+        }
     }
 
     VerticalPager(
         modifier = Modifier.height(224.dp),
         state = state,
         pageSpacing = 16.dp,
-        pageSize = PageSize.Fixed(64.dp)
+        pageSize = PageSize.Fixed(64.dp),
+        snapPosition = SnapPosition.Center
     ) { index ->
         Text(
             text = Meridiem.entries[index % 2].name,

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/SnoozeTimePickerDialog.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/SnoozeTimePickerDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
@@ -42,7 +43,8 @@ fun SnoozeTimePickerDialog(
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = stringResource(id = R.string.minutes),
-                style = MaterialTheme.typography.displaySmall
+                style = MaterialTheme.typography.displaySmall,
+                modifier = Modifier.offset(y = (-8).dp)
             )
         }
     })

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/ScrollTimePicker.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/ScrollTimePicker.kt
@@ -1,6 +1,7 @@
 package com.bnyro.clock.presentation.screens.timer.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.SnapPosition
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerDefaults
@@ -12,6 +13,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -25,18 +28,23 @@ fun ScrollTimePicker(
 ) {
     val primary = MaterialTheme.colorScheme.primary
     val primaryMuted = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-    val state = rememberPagerState(initialPage = maxValue * 100 + value - 1 - offset) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val state = rememberPagerState(initialPage = maxValue * 100 + value - offset) {
         maxValue * 200
     }
-    val currentPage = state.currentPage + 1
+    val currentPage = state.currentPage
     LaunchedEffect(currentPage) {
         onValueChanged((currentPage + offset) % maxValue)
+        if (state.isScrollInProgress) {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+        }
     }
     VerticalPager(
         modifier = Modifier.height(224.dp),
         state = state,
         pageSpacing = 16.dp,
         pageSize = PageSize.Fixed(64.dp),
+        snapPosition = SnapPosition.Center,
         flingBehavior = PagerDefaults.flingBehavior(
             state = state,
             pagerSnapDistance = PagerSnapDistance.atMost(60)

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/ScrollTimePicker.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/ScrollTimePicker.kt
@@ -3,6 +3,7 @@ package com.bnyro.clock.presentation.screens.timer.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.snapping.SnapPosition
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
@@ -40,7 +41,9 @@ fun ScrollTimePicker(
         }
     }
     VerticalPager(
-        modifier = Modifier.height(224.dp),
+        modifier = Modifier
+            .height(224.dp)
+            .widthIn(min = if (maxValue + offset >= 100) 96.dp else 0.dp),
         state = state,
         pageSpacing = 16.dp,
         pageSize = PageSize.Fixed(64.dp),


### PR DESCRIPTION
the wheel pickers currently calculate the selected value one page away from the value that is visually highlighted. this is especially noticeable when releasing the picker between values, where the centered number and stored value can disagree.

this changes the pagers to use `SnapPosition.Center` and treats `state.currentPage` as the selected page instead of applying the previous `+1` offset. the same behaviour is applied to alarm hours, minutes, AM/PM, timer values, and the snooze minute picker.

I also added `HapticFeedbackType.SegmentFrequentTick` while the picker is actively scrolling, enough width for three-digit minute values, and corrected the vertical alignment of the "minutes" label beside the snooze picker.

## related PRs

merge this after [#542](https://github.com/you-apps/ClockYou/pull/542) and before [#530](https://github.com/you-apps/ClockYou/pull/530) and [#534](https://github.com/you-apps/ClockYou/pull/534).

known overlap points:

- if the snooze picker conflicts with #542 or #534, keep the label alignment from [`SnoozeTimePickerDialog.kt` lines 40–48](https://github.com/RisPNG/jay/blob/improve-wheel-picker-sensitivity/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/SnoozeTimePickerDialog.kt#L40-L48) and keep #542's `DialogButton` Save action.
- the reusable wheel behaviour that #530 and #534 should keep is in [`ScrollTimePicker.kt` lines 32–61](https://github.com/RisPNG/jay/blob/improve-wheel-picker-sensitivity/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/ScrollTimePicker.kt#L32-L61).