### PR TITLE
[13/17] Hide the snooze notification action when snooze is disabled

### DIFF
--- a/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
@@ -245,13 +245,6 @@ class AlarmService : Service() {
             getPendingIntent(dismissIntent, 2)
         )
 
-        val snoozeIntent = Intent(ALARM_INTENT_ACTION).putExtra(ACTION_EXTRA_KEY, SNOOZE_ACTION)
-        val snoozeAction = NotificationCompat.Action.Builder(
-            null,
-            getString(R.string.snooze),
-            getPendingIntent(snoozeIntent, 3)
-        )
-
         return NotificationCompat.Builder(context, NotificationHelper.ALARM_CHANNEL).apply {
             setSmallIcon(R.drawable.ic_notification)
             setContentTitle(alarm.label ?: context.getString(R.string.alarm))
@@ -260,7 +253,17 @@ class AlarmService : Service() {
             foregroundServiceBehavior = FOREGROUND_SERVICE_IMMEDIATE
             setCategory(NotificationCompat.CATEGORY_ALARM)
             setFullScreenIntent(pendingIntent, true)
-            addAction(snoozeAction.build())
+            if (alarm.snoozeEnabled) {
+                val snoozeIntent = Intent(ALARM_INTENT_ACTION)
+                    .putExtra(ACTION_EXTRA_KEY, SNOOZE_ACTION)
+                addAction(
+                    NotificationCompat.Action.Builder(
+                        null,
+                        getString(R.string.snooze),
+                        getPendingIntent(snoozeIntent, 3)
+                    ).build()
+                )
+            }
             addAction(dismissAction.build())
             setDeleteIntent(onDeleteIntent)
             setOngoing(false) //maybeeee? it fixes the one thing but i will have to do some tests it seems to work tho


### PR DESCRIPTION
the ringing alarm notification currently always shows a Snooze action even when snooze is disabled for that alarm.

this applies the alarm's existing `snoozeEnabled` condition while building the notification. the Snooze intent and action are only created when the alarm actually permits snoozing, while Dismiss remains available either way.

## related PRs

merge this before [#538](https://github.com/you-apps/ClockYou/pull/538) and [#534](https://github.com/you-apps/ClockYou/pull/534). both later PRs change `AlarmService.kt`; retain the conditional snooze action from [`AlarmService.kt` lines 256–267](https://github.com/RisPNG/jay/blob/notif-snooze-condition-fix/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt#L256-L267) while applying their notification text and timeout changes.