### PR TITLE
[3/17] Fix going back to onboarding screen when pressing back button

### DIFF
--- a/app/src/main/java/com/bnyro/clock/navigation/NavHost.kt
+++ b/app/src/main/java/com/bnyro/clock/navigation/NavHost.kt
@@ -99,7 +99,11 @@ fun AppNavHost(
                     targetOffset = { it / 4 }) + fadeOut()
             }) {
             PermissionScreen {
-                navController.navigate(NavRoutes.Home.route)
+                navController.navigate(NavRoutes.Home.route) {
+                    popUpTo(NavRoutes.Permissions.route) {
+                        inclusive = true
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
after completing or skipping onboarding, pressing Back directly currently return the user to the permission pages.

this navigates to Home with `popUpTo(NavRoutes.Permissions.route)` and `inclusive = true`, removing onboarding from the navigation back stack. once onboarding has been completed or skipped, Back now behaves like it does during a normal app session instead of reopening setup.

I'll attach a recording of completing onboarding, reaching Home, and pressing Back without returning to the permission pages.