### PR TITLE
[1/17] DISCLAIMER + Restore missing-translation checks for full-screen permission strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <string name="app_name" translatable="false">Clock You</string>
     <!-- Navigation -->
     <string name="clock">Clock</string>
@@ -118,8 +118,8 @@
     <string name="all_done_description">Some manufacturers use their own background access permission</string>
     <string name="battery_optimization_title">Disable Battery Optimization</string>
     <string name="battery_optimization_description">This permission is needed for timers to work when the Phone Screen is off.</string>
-    <string name="full_screen_alarm_permission_title" tools:ignore="MissingTranslation">Full-screen alarms</string>
-    <string name="full_screen_alarm_permission_description" tools:ignore="MissingTranslation">Allow full-screen alarms so ringing alarms can appear over the lock screen.</string>
+    <string name="full_screen_alarm_permission_title">Full-screen alarms</string>
+    <string name="full_screen_alarm_permission_description">Allow full-screen alarms so ringing alarms can appear over the lock screen.</string>
     <string name="available_days_0">S</string>
     <string name="available_days_1">M</string>
     <string name="available_days_2">T</string>


### PR DESCRIPTION
## disclaimer

hi, this is the first of 17 remaining PRs to fix some of the issues and improve some of the features that my 2 testers and I encountered while testing the base Clock You app. [#527](https://github.com/you-apps/ClockYou/pull/527) has already been merged. the remaining PR titles start from 1/17 and are numbered in the order that should make them easier to review and merge.

I know it is a lot. it'd be nice if you would consider implementing the changes, but I'd understand if you don't like some of them and reject them. I'm always happy to amend anything if needed. I will keep each unfinished PR in draft until I can provide the attachment(s) showcasing it, which might take a while because I've only drafted the descriptions for now. that's why they are all coming together at once.

---

this follows up on the full-screen alarm permission added in [#527](https://github.com/you-apps/ClockYou/pull/527).

I originally added `tools:ignore="MissingTranslation"` to the two new permission strings to silence the missing translation warning. this doesn't make the strings non-translatable, but it hides the warning and makes it easier for the translations to remain missing.

this removes the suppression and the now-unused `tools` namespace, allowing the full-screen alarm title and description to be handled by the translation workflow like the other translatable strings.

## related PRs

- [#527](https://github.com/you-apps/ClockYou/pull/527) added the full-screen permission strings and was merged before this numbered queue. this PR is the direct follow-up and should be merged first from the remaining queue.
- [#542](https://github.com/you-apps/ClockYou/pull/542) should come next. both PRs touch `strings.xml`; if there is a conflict, keep the unsuppressed full-screen permission strings from [`strings.xml` lines 121–122](https://github.com/RisPNG/jay/blob/revert-translation-supression/app/src/main/res/values/strings.xml#L121-L122), then include #542's dialog strings as normal translatable strings.