### PR TITLE
[10/17] Update running timer notifications when the label changes

### DIFF
--- a/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
@@ -488,6 +488,7 @@ class TimerService : Service() {
     fun updateLabel(id: Int, newLabel: String) {
         timerObjects.firstOrNull { it.id == id }?.let {
             it.label.value = newLabel
+            updateNotification(it)
         }
     }
 


### PR DESCRIPTION
editing a running timer updates the label inside the app, but its notification continues displaying the previous label until another timer state change causes it to refresh.

this calls the existing `updateNotification(timerObject)` immediately after changing the matching timer object's label, keeping the in-app state and notification in sync.

## related PRs

merge this before [#538](https://github.com/you-apps/ClockYou/pull/538). both change `TimerService.kt`; if there is a conflict, retain the notification refresh after a label change from [`TimerService.kt` lines 488–492](https://github.com/RisPNG/jay/blob/timer-label-notif-update-fix/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt#L488-L492) while applying #538's notification text changes.