### PR TITLE
[11/17] Cancel only the matching upcoming alarm notification

### DIFF
--- a/app/src/main/java/com/bnyro/clock/util/receivers/PreAlarmReciever.kt
+++ b/app/src/main/java/com/bnyro/clock/util/receivers/PreAlarmReciever.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.withContext
 
 class PreAlarmReceiver : BroadcastReceiver() {
     companion object {
-        const val PRE_ALARM_OFFSET = 4000
         const val CHANNEL_ID = "upcoming_alarm_channel" //insane crazy name
     }
 
@@ -38,7 +37,7 @@ class PreAlarmReceiver : BroadcastReceiver() {
         }
         val dismissPendingIntent = PendingIntent.getBroadcast(
             context,
-            id.toInt() + PRE_ALARM_OFFSET,
+            id.toInt() + AlarmHelper.PRE_ALARM_ID_OFFSET,
             dismissIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -69,7 +68,10 @@ class PreAlarmReceiver : BroadcastReceiver() {
                             .setAutoCancel(true)
                             .build()
 
-                        notificationManager.notify(id.toInt() + PRE_ALARM_OFFSET, notification)
+                        notificationManager.notify(
+                            id.toInt() + AlarmHelper.PRE_ALARM_ID_OFFSET,
+                            notification
+                        )
                     }
                 }
             } finally {

--- a/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt
@@ -3,7 +3,6 @@ package com.bnyro.clock.util.services
 import android.annotation.SuppressLint
 import android.app.ActivityOptions
 import android.app.Notification
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.BroadcastReceiver
@@ -32,7 +31,6 @@ import com.bnyro.clock.domain.model.Alarm
 import com.bnyro.clock.presentation.screens.alarm.AlarmActivity
 import com.bnyro.clock.util.AlarmHelper
 import com.bnyro.clock.util.NotificationHelper
-import com.bnyro.clock.util.receivers.PreAlarmReceiver
 import kotlinx.coroutines.runBlocking
 import java.util.Timer
 import java.util.TimerTask
@@ -167,19 +165,6 @@ class AlarmService : Service() {
         player.start()
         volumeHandler.post(volumeRunnable)
     }
-    @SuppressLint("ServiceCast")
-    private fun cancelUpcomingAlarmNotifications() {
-        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            nm.activeNotifications.forEach { statusBarNotification ->
-                if (statusBarNotification.notification.channelId == PreAlarmReceiver.CHANNEL_ID) {
-                    nm.cancel(statusBarNotification.tag, statusBarNotification.id)
-                }
-            }
-        } else {
-            nm.cancel(notificationId)
-        }
-    }
     /**
      * Stops alarm
      */
@@ -207,7 +192,9 @@ class AlarmService : Service() {
     }
 
     private fun createNotification(context: Context, alarm: Alarm): Notification {
-        cancelUpcomingAlarmNotifications()
+        NotificationManagerCompat.from(context).cancel(
+            alarm.id.toInt() + AlarmHelper.PRE_ALARM_ID_OFFSET
+        )
         val alarmActivityIntent = Intent(context, AlarmActivity::class.java)
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_USER_ACTION)
             .putExtra(AlarmHelper.EXTRA_ID, alarm.id)


### PR DESCRIPTION
the current alarm service removes upcoming alarm notifications by scanning active notifications for the upcoming alarm channel on Android 8+, while older Android versions fall back to cancelling an unrelated fixed notification ID.

apart from not working correctly on Android 6 and 7, the channel scan can remove upcoming notifications belonging to alarms other than the one that has started ringing.

this removes that single-use implementation and cancels the exact notification using the alarm ID plus `AlarmHelper.PRE_ALARM_ID_OFFSET`. `NotificationManagerCompat.cancel()` supports the project's Android 6+ range, so a separate version-dependent path isn't necessary.

I also removed the duplicated `PreAlarmReceiver.PRE_ALARM_OFFSET` constant and used `AlarmHelper.PRE_ALARM_ID_OFFSET` when creating the notification and its Dismiss `PendingIntent`. this makes creating and cancelling the notification use the same ID calculation.

## related PRs

merge this before [#535](https://github.com/you-apps/ClockYou/pull/535) and [#534](https://github.com/you-apps/ClockYou/pull/534).

known overlap points:

- #535 also changes `PreAlarmReciever.kt`; use the centralized upcoming-notification request code and ID from [`PreAlarmReciever.kt` lines 38–73](https://github.com/RisPNG/jay/blob/upcoming-notif-destroyed-fix/app/src/main/java/com/bnyro/clock/util/receivers/PreAlarmReciever.kt#L38-L73), then add #535's content intent.
- #534 also changes `AlarmService.kt`; retain the matching upcoming-notification cancellation at [`AlarmService.kt` lines 194–197](https://github.com/RisPNG/jay/blob/upcoming-notif-destroyed-fix/app/src/main/java/com/bnyro/clock/util/services/AlarmService.kt#L194-L197).