### PR TITLE
feat: enhance text shadow customization with presets and add text size steps

### DIFF
--- a/app/src/main/java/com/bnyro/clock/domain/model/ClockWidgetOptions.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/ClockWidgetOptions.kt
@@ -1,6 +1,7 @@
 package com.bnyro.clock.domain.model
 
 import com.bnyro.clock.util.widgets.TextColor
+import com.bnyro.clock.domain.model.ShadowPreset
 
 data class ClockWidgetOptions(
     var showDate: Boolean = true,
@@ -12,7 +13,11 @@ data class ClockWidgetOptions(
     var timeTextSize: Float,
     var timeColor: TextColor = TextColor.Primary,
     var dateColor: TextColor = TextColor.Secondary,
-    var useShadowLayout: Boolean = false,
+    var shadowPreset: ShadowPreset = ShadowPreset.OFF,
+    var shadowRadius: Float = 3.0f,
+    var shadowDx: Float = 2.0f,
+    var shadowDy: Float = 2.0f,
+    var shadowAlpha: Float = 0.8f,
     var openAppOnClick: Boolean = true
 ) {
     companion object {
@@ -22,7 +27,8 @@ data class ClockWidgetOptions(
             20f,
             24f,
             28f,
-            32f
+            32f,
+            36f
         )
 
         val timeSizeOptions = listOf(
@@ -42,7 +48,8 @@ data class ClockWidgetOptions(
             88f,
             92f,
             96f,
-            100f
+            100f,
+            104f
         )
 
         val textColorOptions = TextColor.entries.toList()

--- a/app/src/main/java/com/bnyro/clock/domain/model/ShadowPreset.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/ShadowPreset.kt
@@ -1,0 +1,10 @@
+package com.bnyro.clock.domain.model
+
+enum class ShadowPreset(val label: String, val description: String) {
+    OFF("Off", "No text shadow"),
+    SUBTLE("Subtle", "Soft ambient glow"),
+    SOFT("Soft", "Natural drop shadow"),
+    FLOAT("Float", "Downward lighting"),
+    DEEP("Deep", "High depth & blur"),
+    STRONG("Strong", "High contrast")
+}

--- a/app/src/main/java/com/bnyro/clock/presentation/components/ModernStepSlider.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/components/ModernStepSlider.kt
@@ -1,0 +1,116 @@
+package com.bnyro.clock.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSliderState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material 3 Expressive Step Slider using rememberSliderState (M3 1.4.0+).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModernStepSlider(
+    title: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueLabel: String? = null,
+    startLabel: String? = null,
+    endLabel: String? = null,
+    centerLabel: String? = null
+) {
+    val alpha = if (enabled) 1f else 0.38f
+
+    val sliderState = rememberSliderState(
+        value = value,
+        steps = steps,
+        valueRange = valueRange
+    )
+    sliderState.onValueChangeFinished = { onValueChange(sliderState.value) }
+
+    LaunchedEffect(value) {
+        if (sliderState.value != value) {
+            sliderState.value = value
+        }
+    }
+
+    LaunchedEffect(sliderState) {
+        snapshotFlow { sliderState.value }.collect { onValueChange(it) }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(alpha)
+            .padding(vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (valueLabel != null) {
+                Text(
+                    text = valueLabel,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        Slider(
+            state = sliderState,
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        if (startLabel != null || endLabel != null || centerLabel != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = startLabel ?: "",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (centerLabel != null) {
+                    Text(
+                        text = centerLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    text = endLabel ?: "",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
@@ -29,23 +29,42 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.rounded.CalendarToday
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.FormatSize
 import androidx.compose.material.icons.rounded.Language
+import androidx.compose.material.icons.rounded.Layers
+import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.TouchApp
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.ui.draw.rotate
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -55,17 +74,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bnyro.clock.R
 import com.bnyro.clock.domain.model.ClockWidgetOptions
+import com.bnyro.clock.domain.model.ShadowPreset
+import com.bnyro.clock.presentation.components.ModernStepSlider
 import com.bnyro.clock.presentation.components.SwitchItem
 import com.bnyro.clock.presentation.components.SwitchWithDivider
+import java.util.Locale
 import com.bnyro.clock.presentation.screens.clock.components.TimeZonePickerDialog
 import com.bnyro.clock.presentation.screens.clock.model.ClockModel
 import com.bnyro.clock.presentation.screens.settings.model.SettingsModel
@@ -172,7 +196,11 @@ fun DigitalClockWidgetSettings(
     var showDateOption by remember { mutableStateOf(options.showDate) }
     var showTimeOption by remember { mutableStateOf(options.showTime) }
     var showBackgroundOption by remember { mutableStateOf(options.showBackground) }
-    var useShadowLayoutOption by remember { mutableStateOf(options.useShadowLayout) }
+    var shadowPresetOption by remember { mutableStateOf(options.shadowPreset) }
+    var shadowRadiusOption by remember { mutableFloatStateOf(options.shadowRadius) }
+    var shadowDxOption by remember { mutableFloatStateOf(options.shadowDx) }
+    var shadowDyOption by remember { mutableFloatStateOf(options.shadowDy) }
+    var shadowAlphaOption by remember { mutableFloatStateOf(options.shadowAlpha) }
     var openAppOnClickOption by remember { mutableStateOf(options.openAppOnClick) }
 
     var selectedDateSize by remember { mutableFloatStateOf(options.dateTextSize) }
@@ -204,24 +232,24 @@ fun DigitalClockWidgetSettings(
             SwitchItem(
                 title = stringResource(R.string.show_time),
                 isChecked = showTimeOption,
-                icon = Icons.Rounded.CalendarToday
+                icon = Icons.Rounded.Schedule
             ) {
                 showTimeOption = it
             }
             SwitchItem(
                 title = stringResource(R.string.show_widget_background),
                 isChecked = showBackgroundOption,
-                icon = Icons.Rounded.CalendarToday
+                icon = Icons.Rounded.Wallpaper
             ) {
                 showBackgroundOption = it
             }
-            SwitchItem(
-                title = stringResource(R.string.show_text_shadow),
-                isChecked = useShadowLayoutOption,
-                icon = Icons.Rounded.CalendarToday
-            ) {
-                useShadowLayoutOption = it
-            }
+            TextShadowSetting(
+                selectedPreset = shadowPresetOption,
+                shadowDisabled = showBackgroundOption,
+                onPresetChanged = { preset ->
+                    shadowPresetOption = preset
+                }
+            )
             SwitchItem(
                 title = stringResource(R.string.open_app_on_click),
                 isChecked = openAppOnClickOption,
@@ -287,7 +315,11 @@ fun DigitalClockWidgetSettings(
                     timeZone = customTimeZone
                     timeZoneName = customTimeZoneName
                     showBackground = showBackgroundOption
-                    useShadowLayout = useShadowLayoutOption
+                    shadowPreset = shadowPresetOption
+                    shadowRadius = shadowRadiusOption
+                    shadowDx = shadowDxOption
+                    shadowDy = shadowDyOption
+                    shadowAlpha = shadowAlphaOption
                     openAppOnClick = openAppOnClickOption
                 }
                 onComplete.invoke(options)
@@ -446,4 +478,222 @@ fun TextSizeSelectSettingPreview() {
         currentSize = 16f,
         onSizeSelected = {}
     )
+}
+
+/**
+ * Modern Material 3 Expressive Text Shadow setting:
+ * - Master switch item with Layers icon and background-disabled warning
+ * - M3 Expressive Segmented/Connected Group Card pattern:
+ *   - Outer radius: 28dp (extra-large), Inner adjacent radius: 4dp (concentric)
+ *   - Separated trigger card and content card with 4dp gap
+ *   - Smooth corner-radius morphing (28dp -> 4dp) on expand/collapse
+ *   - Circular tonal avatar icon badge
+ *   - True working step slider for the 5 shadow intensity presets:
+ *     1. Subtle (Soft ambient glow)
+ *     2. Soft (Natural drop shadow)
+ *     3. Float (Downward lighting)
+ *     4. Deep (High depth & blur)
+ *     5. Strong (High contrast outline)
+ */
+@Composable
+fun TextShadowSetting(
+    selectedPreset: ShadowPreset,
+    shadowDisabled: Boolean,
+    onPresetChanged: (ShadowPreset) -> Unit
+) {
+    val isEnabled = selectedPreset != ShadowPreset.OFF && !shadowDisabled
+    var showAdvanced by remember { mutableStateOf(false) }
+    val alpha = if (shadowDisabled) 0.38f else 1f
+
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (showAdvanced) 180f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "chevronRotation"
+    )
+
+    // Morph bottom corners of trigger from 28.dp to 4.dp when expanded
+    val triggerBottomRadius by animateDpAsState(
+        targetValue = if (showAdvanced) 4.dp else 28.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "triggerBottomRadius"
+    )
+
+    val activePresetIndex = when (selectedPreset) {
+        ShadowPreset.SUBTLE -> 1f
+        ShadowPreset.SOFT -> 2f
+        ShadowPreset.FLOAT -> 3f
+        ShadowPreset.DEEP -> 4f
+        ShadowPreset.STRONG -> 5f
+        ShadowPreset.OFF -> 2f
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(alpha)
+    ) {
+        SwitchItem(
+            title = stringResource(R.string.show_text_shadow),
+            description = if (shadowDisabled) stringResource(R.string.shadow_unavailable_with_background) else null,
+            isChecked = isEnabled,
+            icon = Icons.Rounded.Layers
+        ) { checked ->
+            if (!shadowDisabled) {
+                if (checked) {
+                    onPresetChanged(ShadowPreset.SOFT)
+                } else {
+                    onPresetChanged(ShadowPreset.OFF)
+                }
+            }
+        }
+
+        if (isEnabled) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 6.dp)
+            ) {
+                // 1. Trigger Card (Top)
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(
+                        topStart = 28.dp,
+                        topEnd = 28.dp,
+                        bottomStart = triggerBottomRadius,
+                        bottomEnd = triggerBottomRadius
+                    ),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showAdvanced = !showAdvanced }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(42.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.primaryContainer),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Tune,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(22.dp),
+                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                            }
+                            Spacer(modifier = Modifier.size(14.dp))
+                            Column {
+                                Text(
+                                    text = stringResource(R.string.advanced_shadow_settings),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = "Style: ${selectedPreset.label} — ${selectedPreset.description}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        Icon(
+                            imageVector = Icons.Rounded.ExpandMore,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .padding(start = 8.dp)
+                                .rotate(chevronRotation),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                // 2. Content Card (Separated with concentric gap and radii)
+                AnimatedVisibility(
+                    visible = showAdvanced,
+                    enter = expandVertically(
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioLowBouncy,
+                            stiffness = Spring.StiffnessMediumLow
+                        )
+                    ) + fadeIn(),
+                    exit = shrinkVertically(
+                        animationSpec = spring(
+                            stiffness = Spring.StiffnessMediumLow
+                        )
+                    ) + fadeOut()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
+                    ) {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(
+                                topStart = 4.dp,
+                                topEnd = 4.dp,
+                                bottomStart = 28.dp,
+                                bottomEnd = 28.dp
+                            ),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                            )
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 14.dp)
+                            ) {
+                                ModernStepSlider(
+                                    title = "Shadow Intensity & Style",
+                                    value = activePresetIndex,
+                                    onValueChange = { index ->
+                                        val rounded = index.toInt().coerceIn(1, 5)
+                                        val newPreset = when (rounded) {
+                                            1 -> ShadowPreset.SUBTLE
+                                            2 -> ShadowPreset.SOFT
+                                            3 -> ShadowPreset.FLOAT
+                                            4 -> ShadowPreset.DEEP
+                                            5 -> ShadowPreset.STRONG
+                                            else -> ShadowPreset.SOFT
+                                        }
+                                        onPresetChanged(newPreset)
+                                    },
+                                    valueRange = 1f..5f,
+                                    steps = 3,
+                                    valueLabel = selectedPreset.label,
+                                    startLabel = "Subtle",
+                                    centerLabel = "Float",
+                                    endLabel = "Strong"
+                                )
+                                Spacer(modifier = Modifier.height(6.dp))
+                                Text(
+                                    text = selectedPreset.description,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/DigitalClockWidget.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/DigitalClockWidget.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.RemoteViews
 import com.bnyro.clock.R
 import com.bnyro.clock.domain.model.ClockWidgetOptions
+import com.bnyro.clock.domain.model.ShadowPreset
 import com.bnyro.clock.ui.MainActivity
 import com.bnyro.clock.util.widgets.getColorValue
 import com.bnyro.clock.util.widgets.loadClockWidgetSettings
@@ -24,7 +25,7 @@ class DigitalClockWidget : TextWidgetProvider() {
         val DefaultConfig = ClockWidgetOptions(
             dateTextSize = 16f,
             timeTextSize = 52f,
-            useShadowLayout = false,
+            shadowPreset = ShadowPreset.OFF,
             openAppOnClick = true
         )
 
@@ -32,15 +33,39 @@ class DigitalClockWidget : TextWidgetProvider() {
             context: Context,
             options: ClockWidgetOptions
         ) {
-            val normalVisibility = if (options.useShadowLayout) View.GONE else View.VISIBLE
-            val shadowVisibility = if (options.useShadowLayout) View.VISIBLE else View.GONE
+            val effectivePreset = if (options.showBackground) ShadowPreset.OFF else options.shadowPreset
 
-            setViewVisibility(R.id.container_normal, normalVisibility)
-            setViewVisibility(R.id.container_shadow, shadowVisibility)
+            setViewVisibility(R.id.container_normal,        if (effectivePreset == ShadowPreset.OFF)    View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_subtle, if (effectivePreset == ShadowPreset.SUBTLE) View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_soft,   if (effectivePreset == ShadowPreset.SOFT)   View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_float,  if (effectivePreset == ShadowPreset.FLOAT)  View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_deep,   if (effectivePreset == ShadowPreset.DEEP)   View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_strong, if (effectivePreset == ShadowPreset.STRONG) View.VISIBLE else View.GONE)
 
-            val dateId = if (options.useShadowLayout) R.id.textClock_shadow else R.id.textClock
-            val timeId = if (options.useShadowLayout) R.id.textClock2_shadow else R.id.textClock2
-            val cityId = if (options.useShadowLayout) R.id.cityName_shadow else R.id.cityName
+            val dateId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.textClock_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.textClock_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.textClock_shadow_float
+                ShadowPreset.DEEP   -> R.id.textClock_shadow_deep
+                ShadowPreset.STRONG -> R.id.textClock_shadow_strong
+                else                -> R.id.textClock
+            }
+            val timeId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.textClock2_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.textClock2_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.textClock2_shadow_float
+                ShadowPreset.DEEP   -> R.id.textClock2_shadow_deep
+                ShadowPreset.STRONG -> R.id.textClock2_shadow_strong
+                else                -> R.id.textClock2
+            }
+            val cityId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.cityName_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.cityName_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.cityName_shadow_float
+                ShadowPreset.DEEP   -> R.id.cityName_shadow_deep
+                ShadowPreset.STRONG -> R.id.cityName_shadow_strong
+                else                -> R.id.cityName
+            }
 
             val dateVisibility = if (options.showDate) View.VISIBLE else View.GONE
             val timeVisibility = if (options.showTime) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/VerticalClockWidget.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/VerticalClockWidget.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.RemoteViews
 import com.bnyro.clock.R
 import com.bnyro.clock.domain.model.ClockWidgetOptions
+import com.bnyro.clock.domain.model.ShadowPreset
 import com.bnyro.clock.ui.MainActivity
 import com.bnyro.clock.util.widgets.getColorValue
 import com.bnyro.clock.util.widgets.loadClockWidgetSettings
@@ -24,7 +25,7 @@ class VerticalClockWidget : TextWidgetProvider() {
         val DefaultConfig = ClockWidgetOptions(
             dateTextSize = 10f,
             timeTextSize = 80f,
-            useShadowLayout = false,
+            shadowPreset = ShadowPreset.OFF,
             openAppOnClick = true
         )
 
@@ -32,17 +33,47 @@ class VerticalClockWidget : TextWidgetProvider() {
             context: Context,
             options: ClockWidgetOptions
         ) {
+            val effectivePreset = if (options.showBackground) ShadowPreset.OFF else options.shadowPreset
 
-            val normalVisibility = if (options.useShadowLayout) View.GONE else View.VISIBLE
-            val shadowVisibility = if (options.useShadowLayout) View.VISIBLE else View.GONE
+            setViewVisibility(R.id.container_normal,        if (effectivePreset == ShadowPreset.OFF)    View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_subtle, if (effectivePreset == ShadowPreset.SUBTLE) View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_soft,   if (effectivePreset == ShadowPreset.SOFT)   View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_float,  if (effectivePreset == ShadowPreset.FLOAT)  View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_deep,   if (effectivePreset == ShadowPreset.DEEP)   View.VISIBLE else View.GONE)
+            setViewVisibility(R.id.container_shadow_strong, if (effectivePreset == ShadowPreset.STRONG) View.VISIBLE else View.GONE)
 
-            setViewVisibility(R.id.container_normal, normalVisibility)
-            setViewVisibility(R.id.container_shadow, shadowVisibility)
-
-            val dateId = if (options.useShadowLayout) R.id.textClockDate_shadow else R.id.textClockDate
-            val hoursId = if (options.useShadowLayout) R.id.textClockHours_shadow else R.id.textClockHours
-            val minutesId = if (options.useShadowLayout) R.id.textClockMinutes_shadow else R.id.textClockMinutes
-            val cityId = if (options.useShadowLayout) R.id.cityName_shadow else R.id.cityName
+            val dateId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.textClockDate_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.textClockDate_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.textClockDate_shadow_float
+                ShadowPreset.DEEP   -> R.id.textClockDate_shadow_deep
+                ShadowPreset.STRONG -> R.id.textClockDate_shadow_strong
+                else                -> R.id.textClockDate
+            }
+            val hoursId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.textClockHours_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.textClockHours_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.textClockHours_shadow_float
+                ShadowPreset.DEEP   -> R.id.textClockHours_shadow_deep
+                ShadowPreset.STRONG -> R.id.textClockHours_shadow_strong
+                else                -> R.id.textClockHours
+            }
+            val minutesId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.textClockMinutes_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.textClockMinutes_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.textClockMinutes_shadow_float
+                ShadowPreset.DEEP   -> R.id.textClockMinutes_shadow_deep
+                ShadowPreset.STRONG -> R.id.textClockMinutes_shadow_strong
+                else                -> R.id.textClockMinutes
+            }
+            val cityId = when (effectivePreset) {
+                ShadowPreset.SUBTLE -> R.id.cityName_shadow_subtle
+                ShadowPreset.SOFT   -> R.id.cityName_shadow_soft
+                ShadowPreset.FLOAT  -> R.id.cityName_shadow_float
+                ShadowPreset.DEEP   -> R.id.cityName_shadow_deep
+                ShadowPreset.STRONG -> R.id.cityName_shadow_strong
+                else                -> R.id.cityName
+            }
 
             val dateVisibility = if (options.showDate) View.VISIBLE else View.GONE
             val timeVisibility = if (options.showTime) View.VISIBLE else View.GONE
@@ -63,7 +94,6 @@ class VerticalClockWidget : TextWidgetProvider() {
             setString(minutesId, "setTimeZone", options.timeZone)
             setString(dateId, "setTimeZone", options.timeZone)
             setTextViewText(cityId, options.timeZoneName)
-
 
             val timeColor = options.timeColor.getColorValue(context)
             val dateColor = options.dateColor.getColorValue(context)

--- a/app/src/main/java/com/bnyro/clock/util/widgets/TextClockWIdget.kt
+++ b/app/src/main/java/com/bnyro/clock/util/widgets/TextClockWIdget.kt
@@ -3,6 +3,7 @@ package com.bnyro.clock.util.widgets
 import android.content.Context
 import androidx.core.content.edit
 import com.bnyro.clock.domain.model.ClockWidgetOptions
+import com.bnyro.clock.domain.model.ShadowPreset
 
 fun Context.saveClockWidgetSettings(
     appWidgetId: Int,
@@ -17,7 +18,12 @@ fun Context.saveClockWidgetSettings(
     putBoolean(PREF_SHOW_BACKGROUND + appWidgetId, options.showBackground)
     putInt(PREF_DATE_TEXT_COLOR + appWidgetId, options.dateColor.attrInt)
     putInt(PREF_TIME_TEXT_COLOR + appWidgetId, options.timeColor.attrInt)
-    putBoolean(PREF_USE_SHADOW_LAYOUT + appWidgetId, options.useShadowLayout)
+    putBoolean(PREF_OPEN_APP_ON_CLICK + appWidgetId, options.openAppOnClick)
+    putString(PREF_SHADOW_PRESET + appWidgetId, options.shadowPreset.name)
+    putFloat(PREF_SHADOW_RADIUS + appWidgetId, options.shadowRadius)
+    putFloat(PREF_SHADOW_DX + appWidgetId, options.shadowDx)
+    putFloat(PREF_SHADOW_DY + appWidgetId, options.shadowDy)
+    putFloat(PREF_SHADOW_ALPHA + appWidgetId, options.shadowAlpha)
 }
 
 fun Context.loadClockWidgetSettings(
@@ -71,9 +77,37 @@ fun Context.loadClockWidgetSettings(
     } ?: defaultClockWidgetOptions.timeColor
 
 
-    val useShadowLayout = getBoolean(
-        PREF_USE_SHADOW_LAYOUT + appWidgetId,
-        defaultClockWidgetOptions.useShadowLayout
+    // Migration: if the new key is absent but the legacy boolean exists, promote it once.
+    val shadowPreset = if (contains(PREF_SHADOW_PRESET + appWidgetId)) {
+        val name = getString(PREF_SHADOW_PRESET + appWidgetId, ShadowPreset.OFF.name) ?: ShadowPreset.OFF.name
+        runCatching { ShadowPreset.valueOf(name) }.getOrDefault(ShadowPreset.OFF)
+    } else if (contains(PREF_USE_SHADOW_LAYOUT + appWidgetId)) {
+        val legacy = getBoolean(PREF_USE_SHADOW_LAYOUT + appWidgetId, false)
+        if (legacy) ShadowPreset.STRONG else ShadowPreset.OFF
+    } else {
+        defaultClockWidgetOptions.shadowPreset
+    }
+
+    val shadowRadius = getFloat(
+        PREF_SHADOW_RADIUS + appWidgetId,
+        defaultClockWidgetOptions.shadowRadius
+    )
+    val shadowDx = getFloat(
+        PREF_SHADOW_DX + appWidgetId,
+        defaultClockWidgetOptions.shadowDx
+    )
+    val shadowDy = getFloat(
+        PREF_SHADOW_DY + appWidgetId,
+        defaultClockWidgetOptions.shadowDy
+    )
+    val shadowAlpha = getFloat(
+        PREF_SHADOW_ALPHA + appWidgetId,
+        defaultClockWidgetOptions.shadowAlpha
+    )
+
+    val openAppOnClick = getBoolean(
+        PREF_OPEN_APP_ON_CLICK + appWidgetId,
+        defaultClockWidgetOptions.openAppOnClick
     )
 
     return ClockWidgetOptions(
@@ -86,7 +120,12 @@ fun Context.loadClockWidgetSettings(
         timeZone = timeZone,
         timeZoneName = timeZoneName,
         showBackground = showBackground,
-        useShadowLayout = useShadowLayout
+        shadowPreset = shadowPreset,
+        shadowRadius = shadowRadius,
+        shadowDx = shadowDx,
+        shadowDy = shadowDy,
+        shadowAlpha = shadowAlpha,
+        openAppOnClick = openAppOnClick
     )
 }
 
@@ -101,5 +140,10 @@ fun Context.deleteClockWidgetPref(appWidgetId: Int) =
         remove(PREF_TIME_ZONE_NAME + appWidgetId)
         remove(PREF_DATE_TEXT_COLOR + appWidgetId)
         remove(PREF_TIME_TEXT_COLOR + appWidgetId)
-        remove(PREF_USE_SHADOW_LAYOUT + appWidgetId)
+        remove(PREF_USE_SHADOW_LAYOUT + appWidgetId) // legacy
+        remove(PREF_SHADOW_PRESET + appWidgetId)
+        remove(PREF_SHADOW_RADIUS + appWidgetId)
+        remove(PREF_SHADOW_DX + appWidgetId)
+        remove(PREF_SHADOW_DY + appWidgetId)
+        remove(PREF_SHADOW_ALPHA + appWidgetId)
     }

--- a/app/src/main/java/com/bnyro/clock/util/widgets/WidgetPreferences.kt
+++ b/app/src/main/java/com/bnyro/clock/util/widgets/WidgetPreferences.kt
@@ -18,7 +18,12 @@ internal const val PREF_TIME_ZONE_NAME = "timeZoneName:"
 internal const val PREF_TIME_TEXT_COLOR = "timeTextColor:"
 internal const val PREF_DATE_TEXT_COLOR = "dateTextColor:"
 
-internal const val PREF_USE_SHADOW_LAYOUT = "useShadowLayout:"
+internal const val PREF_USE_SHADOW_LAYOUT = "useShadowLayout:" // legacy — migration only
+internal const val PREF_SHADOW_PRESET = "shadowPreset:"
+internal const val PREF_SHADOW_RADIUS = "shadowRadius:"
+internal const val PREF_SHADOW_DX = "shadowDx:"
+internal const val PREF_SHADOW_DY = "shadowDy:"
+internal const val PREF_SHADOW_ALPHA = "shadowAlpha:"
 
 internal const val PREF_OPEN_APP_ON_CLICK = "openAppOnClick:"
 

--- a/app/src/main/res/layout/digital_clock.xml
+++ b/app/src/main/res/layout/digital_clock.xml
@@ -9,6 +9,7 @@
         android:paddingVertical="@dimen/_3sdp"
         android:gravity="center|center_vertical">
 
+    <!-- 0. No shadow (OFF) -->
     <LinearLayout
             android:id="@+id/container_normal"
             android:layout_width="wrap_content"
@@ -51,8 +52,9 @@
                 android:singleLine="true" />
     </LinearLayout>
 
+    <!-- 1. Subtle Glow (SUBTLE) -->
     <LinearLayout
-            android:id="@+id/container_shadow"
+            android:id="@+id/container_shadow_subtle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -61,7 +63,7 @@
             android:visibility="gone">
 
         <TextView
-                android:id="@+id/cityName_shadow"
+                android:id="@+id/cityName_shadow_subtle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="?attr/colorSecondary"
@@ -70,13 +72,13 @@
                 android:textSize="@dimen/_8sdp"
                 android:includeFontPadding="false"
                 android:padding="2dp"
-                android:shadowColor="#D0000000"
-                android:shadowDx="2.0"
-                android:shadowDy="2.0"
-                android:shadowRadius="3.0" />
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.0" />
 
         <TextClock
-                android:id="@+id/textClock_shadow"
+                android:id="@+id/textClock_shadow_subtle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:format12Hour="EE, MMM dd"
@@ -86,13 +88,196 @@
                 android:textSize="@dimen/_8sdp"
                 android:includeFontPadding="false"
                 android:padding="2dp"
-                android:shadowColor="#D0000000"
-                android:shadowDx="2.0"
-                android:shadowDy="2.0"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.0" />
+
+        <TextClock
+                android:id="@+id/textClock2_shadow_subtle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:format12Hour="h:mm a"
+                android:format24Hour="HH:mm"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_40sdp"
+                android:textStyle="bold"
+                android:text="12:34"
+                android:singleLine="true"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="3.0" />
+    </LinearLayout>
+
+    <!-- 2. Soft Drop Shadow (SOFT) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_soft"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextView
+                android:id="@+id/cityName_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.0"
+                android:shadowDy="1.0"
+                android:shadowRadius="2.5" />
+
+        <TextClock
+                android:id="@+id/textClock_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:textColor="?attr/colorSecondary"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.0"
+                android:shadowDy="1.0"
+                android:shadowRadius="2.5" />
+
+        <TextClock
+                android:id="@+id/textClock2_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:format12Hour="h:mm a"
+                android:format24Hour="HH:mm"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_40sdp"
+                android:textStyle="bold"
+                android:text="12:34"
+                android:singleLine="true"
+                android:includeFontPadding="false"
+                android:padding="4dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.5"
+                android:shadowDy="1.5"
+                android:shadowRadius="3.0" />
+    </LinearLayout>
+
+    <!-- 3. Downward Float (FLOAT) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_float"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextView
+                android:id="@+id/cityName_shadow_float"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="1.5"
                 android:shadowRadius="3.0" />
 
         <TextClock
-                android:id="@+id/textClock2_shadow"
+                android:id="@+id/textClock_shadow_float"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:textColor="?attr/colorSecondary"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="1.5"
+                android:shadowRadius="3.0" />
+
+        <TextClock
+                android:id="@+id/textClock2_shadow_float"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:format12Hour="h:mm a"
+                android:format24Hour="HH:mm"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_40sdp"
+                android:textStyle="bold"
+                android:text="12:34"
+                android:singleLine="true"
+                android:includeFontPadding="false"
+                android:padding="5dp"
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="4.0" />
+    </LinearLayout>
+
+    <!-- 4. Deep Depth (DEEP) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_deep"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextView
+                android:id="@+id/cityName_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="1.5"
+                android:shadowDy="2.0"
+                android:shadowRadius="4.0" />
+
+        <TextClock
+                android:id="@+id/textClock_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:textColor="?attr/colorSecondary"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="1.5"
+                android:shadowDy="2.0"
+                android:shadowRadius="4.0" />
+
+        <TextClock
+                android:id="@+id/textClock2_shadow_deep"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/_minus2sdp"
@@ -105,7 +290,68 @@
                 android:singleLine="true"
                 android:includeFontPadding="false"
                 android:padding="6dp"
-                android:shadowColor="#D0000000"
+                android:shadowColor="#CC000000"
+                android:shadowDx="2.0"
+                android:shadowDy="3.0"
+                android:shadowRadius="5.5" />
+    </LinearLayout>
+
+    <!-- 5. High Contrast Outline (STRONG) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_strong"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextView
+                android:id="@+id/cityName_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#FF000000"
+                android:shadowDx="2.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="3.5" />
+
+        <TextClock
+                android:id="@+id/textClock_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:textColor="?attr/colorSecondary"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#FF000000"
+                android:shadowDx="2.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="3.5" />
+
+        <TextClock
+                android:id="@+id/textClock2_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:format12Hour="h:mm a"
+                android:format24Hour="HH:mm"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_40sdp"
+                android:textStyle="bold"
+                android:text="12:34"
+                android:singleLine="true"
+                android:includeFontPadding="false"
+                android:padding="6dp"
+                android:shadowColor="#FF000000"
                 android:shadowDx="2.5"
                 android:shadowDy="2.5"
                 android:shadowRadius="4.0" />

--- a/app/src/main/res/layout/vertical_clock.xml
+++ b/app/src/main/res/layout/vertical_clock.xml
@@ -10,6 +10,7 @@
         android:paddingVertical="@dimen/_3sdp"
         android:gravity="center|center_vertical">
 
+    <!-- 0. No shadow (OFF) -->
     <LinearLayout
             android:id="@+id/container_normal"
             android:layout_width="wrap_content"
@@ -68,8 +69,9 @@
                 tools:visibility="visible" />
     </LinearLayout>
 
+    <!-- 1. Subtle Glow (SUBTLE) -->
     <LinearLayout
-            android:id="@+id/container_shadow"
+            android:id="@+id/container_shadow_subtle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -77,7 +79,7 @@
             android:visibility="gone">
 
         <TextClock
-                android:id="@+id/textClockDate_shadow"
+                android:id="@+id/textClockDate_shadow_subtle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -88,13 +90,179 @@
                 android:textColor="?attr/colorSecondary"
                 android:includeFontPadding="false"
                 android:padding="2dp"
-                android:shadowColor="#D0000000"
-                android:shadowDx="2.0"
-                android:shadowDy="2.0"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.0" />
+
+        <TextClock
+                android:id="@+id/textClockHours_shadow_subtle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:layout_gravity="center"
+                android:format12Hour="h a"
+                android:format24Hour="HH"
+                android:text="12"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.5" />
+
+        <TextClock
+                android:id="@+id/textClockMinutes_shadow_subtle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="mm"
+                android:format24Hour="mm"
+                android:text="34"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:textStyle="bold"
+                android:layout_marginTop="@dimen/_minus25sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.5" />
+
+        <TextView
+                android:id="@+id/cityName_shadow_subtle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:layout_gravity="center"
+                android:textAlignment="center"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#66000000"
+                android:shadowDx="0.0"
+                android:shadowDy="0.0"
+                android:shadowRadius="2.0"
+                tools:visibility="visible" />
+    </LinearLayout>
+
+    <!-- 2. Soft Drop Shadow (SOFT) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_soft"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextClock
+                android:id="@+id/textClockDate_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:textColor="?attr/colorSecondary"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.0"
+                android:shadowDy="1.0"
+                android:shadowRadius="2.5" />
+
+        <TextClock
+                android:id="@+id/textClockHours_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:layout_gravity="center"
+                android:format12Hour="h a"
+                android:format24Hour="HH"
+                android:text="12"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.5"
+                android:shadowDy="1.5"
+                android:shadowRadius="2.5" />
+
+        <TextClock
+                android:id="@+id/textClockMinutes_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="mm"
+                android:format24Hour="mm"
+                android:text="34"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:textStyle="bold"
+                android:layout_marginTop="@dimen/_minus25sdp"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.5"
+                android:shadowDy="1.5"
+                android:shadowRadius="2.5" />
+
+        <TextView
+                android:id="@+id/cityName_shadow_soft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:layout_gravity="center"
+                android:textAlignment="center"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#99000000"
+                android:shadowDx="1.0"
+                android:shadowDy="1.0"
+                android:shadowRadius="2.0"
+                tools:visibility="visible" />
+    </LinearLayout>
+
+    <!-- 3. Downward Float (FLOAT) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_float"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextClock
+                android:id="@+id/textClockDate_shadow_float"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:textColor="?attr/colorSecondary"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="1.5"
                 android:shadowRadius="3.0" />
 
         <TextClock
-                android:id="@+id/textClockHours_shadow"
+                android:id="@+id/textClockHours_shadow_float"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/_minus2sdp"
@@ -107,13 +275,13 @@
                 android:textSize="@dimen/_60sdp"
                 android:includeFontPadding="false"
                 android:padding="4dp"
-                android:shadowColor="#D0000000"
-                android:shadowDx="2.5"
-                android:shadowDy="2.5"
-                android:shadowRadius="4.0" />
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="3.5" />
 
         <TextClock
-                android:id="@+id/textClockMinutes_shadow"
+                android:id="@+id/textClockMinutes_shadow_float"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -126,13 +294,13 @@
                 android:layout_marginTop="@dimen/_minus25sdp"
                 android:includeFontPadding="false"
                 android:padding="4dp"
-                android:shadowColor="#D0000000"
-                android:shadowDx="2.5"
-                android:shadowDy="2.5"
-                android:shadowRadius="4.0" />
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="3.5" />
 
         <TextView
-                android:id="@+id/cityName_shadow"
+                android:id="@+id/cityName_shadow_float"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="?attr/colorSecondary"
@@ -143,10 +311,176 @@
                 android:textAlignment="center"
                 android:includeFontPadding="false"
                 android:padding="2dp"
-                android:shadowColor="#D0000000"
+                android:shadowColor="#B3000000"
+                android:shadowDx="0.0"
+                android:shadowDy="1.5"
+                android:shadowRadius="3.0"
+                tools:visibility="visible" />
+    </LinearLayout>
+
+    <!-- 4. Deep Depth (DEEP) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_deep"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextClock
+                android:id="@+id/textClockDate_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:textColor="?attr/colorSecondary"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="1.5"
+                android:shadowDy="2.0"
+                android:shadowRadius="4.0" />
+
+        <TextClock
+                android:id="@+id/textClockHours_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:layout_gravity="center"
+                android:format12Hour="h a"
+                android:format24Hour="HH"
+                android:text="12"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:includeFontPadding="false"
+                android:padding="5dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="2.0"
+                android:shadowDy="3.0"
+                android:shadowRadius="5.0" />
+
+        <TextClock
+                android:id="@+id/textClockMinutes_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="mm"
+                android:format24Hour="mm"
+                android:text="34"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:textStyle="bold"
+                android:layout_marginTop="@dimen/_minus25sdp"
+                android:includeFontPadding="false"
+                android:padding="5dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="2.0"
+                android:shadowDy="3.0"
+                android:shadowRadius="5.0" />
+
+        <TextView
+                android:id="@+id/cityName_shadow_deep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:layout_gravity="center"
+                android:textAlignment="center"
+                android:includeFontPadding="false"
+                android:padding="3dp"
+                android:shadowColor="#CC000000"
+                android:shadowDx="1.5"
+                android:shadowDy="2.0"
+                android:shadowRadius="4.0"
+                tools:visibility="visible" />
+    </LinearLayout>
+
+    <!-- 5. High Contrast Outline (STRONG) -->
+    <LinearLayout
+            android:id="@+id/container_shadow_strong"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_centerInParent="true"
+            android:visibility="gone">
+
+        <TextClock
+                android:id="@+id/textClockDate_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="EE, MMM dd"
+                android:format24Hour="EE, MMM dd"
+                android:text="Today"
+                android:textSize="@dimen/_8sdp"
+                android:textColor="?attr/colorSecondary"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#FF000000"
                 android:shadowDx="2.0"
                 android:shadowDy="2.0"
-                android:shadowRadius="3.0"
+                android:shadowRadius="3.5" />
+
+        <TextClock
+                android:id="@+id/textClockHours_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_minus2sdp"
+                android:layout_gravity="center"
+                android:format12Hour="h a"
+                android:format24Hour="HH"
+                android:text="12"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:includeFontPadding="false"
+                android:padding="4dp"
+                android:shadowColor="#FF000000"
+                android:shadowDx="2.5"
+                android:shadowDy="2.5"
+                android:shadowRadius="4.0" />
+
+        <TextClock
+                android:id="@+id/textClockMinutes_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:format12Hour="mm"
+                android:format24Hour="mm"
+                android:text="34"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/_60sdp"
+                android:textStyle="bold"
+                android:layout_marginTop="@dimen/_minus25sdp"
+                android:includeFontPadding="false"
+                android:padding="4dp"
+                android:shadowColor="#FF000000"
+                android:shadowDx="2.5"
+                android:shadowDy="2.5"
+                android:shadowRadius="4.0" />
+
+        <TextView
+                android:id="@+id/cityName_shadow_strong"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/colorSecondary"
+                android:text="America"
+                android:visibility="gone"
+                android:textSize="@dimen/_8sdp"
+                android:layout_gravity="center"
+                android:textAlignment="center"
+                android:includeFontPadding="false"
+                android:padding="2dp"
+                android:shadowColor="#FF000000"
+                android:shadowDx="2.0"
+                android:shadowDy="2.0"
+                android:shadowRadius="3.5"
                 tools:visibility="visible" />
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,4 +198,10 @@
     <string name="time_text_color">Time text color</string>
     <string name="credits">Created by You-Apps, maintained by Elektron</string>
     <string name="advanced_settings">advanced settings</string>
+    <string name="shadow_unavailable_with_background">Shadow unavailable when background is shown</string>
+    <string name="advanced_shadow_settings">Advanced shadow settings</string>
+    <string name="shadow_blur">Blur radius</string>
+    <string name="shadow_offset_x">Horizontal offset (X)</string>
+    <string name="shadow_offset_y">Vertical offset (Y)</string>
+    <string name="shadow_opacity">Shadow opacity</string>
 </resources>


### PR DESCRIPTION
### Summary of Changes

#### 1. Text Shadow Presets (Closes #493)
Replaced the binary shadow toggle with 5 curated shadow presets to improve contrast across different wallpapers while adhering to Android `RemoteViews` / `TextClock` limitations:
- **Subtle**: `(0, 0)` offset, `2.0dp` blur (40% opacity)
- **Soft**: `(1.0dp, 1.0dp)` offset, `2.5dp` blur (60% opacity)
- **Float**: `(0, 2.0dp)` offset, `3.5dp` blur (70% opacity)
- **Deep**: `(2.0dp, 3.0dp)` offset, `5.0dp` blur (80% opacity)
- **Strong**: `(2.5dp, 2.5dp)` offset, `4.0dp` blur (100% opacity)
- Added an interactive step slider under an expandable card with live preset labels.
- Automatically migrates legacy `useShadowLayout` boolean to `ShadowPreset.STRONG`.

#### 2. Fixed Settings Icons
Replaced copy-pasted `CalendarToday` icons in `ClockWidgetConfig` with proper icons:
- **Show widget background**: `CalendarToday` → `Icons.Rounded.Wallpaper`
- **Show text shadow**: `CalendarToday` → `Icons.Rounded.Layers`

#### 3. Expanded Text Size Steps
- Added `36sp` to `dateSizeOptions` (now `12sp` .. `36sp`).
- Added `104sp` to `timeSizeOptions` (now `36sp` .. `104sp`).

---

### Verification
- [x] Verified all 5 shadow styles on physical device (Digital & Vertical widgets)
- [x] Verified background suppression logic (shadow disables when background is enabled)
- [x] Verified `./gradlew assembleDebug` compiles cleanly