### PR TITLE
fix delete buttons pill colour fill

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/components/DialogButton.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/components/DialogButton.kt
@@ -32,7 +32,7 @@ fun DialogButton(
         DialogButtonStyle.DESTRUCTIVE -> FilledTonalButton(
             onClick = onClick,
             colors = ButtonDefaults.filledTonalButtonColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                 contentColor = MaterialTheme.colorScheme.error
             )
         ) {

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/TimerScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/TimerScreen.kt
@@ -348,7 +348,7 @@ private fun SelectionActionButtons(
                 .weight(1f)
                 .height(buttonHeight),
             colors = ButtonDefaults.filledTonalButtonColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                 contentColor = MaterialTheme.colorScheme.error
             ),
             onClick = {


### PR DESCRIPTION
Fixes this:
<img width="748" height="499" alt="image" src="https://github.com/user-attachments/assets/7ec4c87c-d2ed-40c3-9e99-c67cf46f89d6" />

this follows up on #542, which added the `DESTRUCTIVE` style to the shared `DialogButton`.

the destructive style fills its container with `surfaceContainerHigh`, and Material 3 resolves the alert dialog container from `DialogTokens.ContainerColor`, which is the same role. the Delete pill ends up exactly the colour of the dialog behind it, so it disappears and the action reads as loose red text next to an outlined Cancel.

this fills it with `surfaceContainerHighest` instead, one step above the dialog surface. it covers deleting selected alarms, swiping a single alarm away, and deleting a world clock.

I also gave the timer's preset selection Delete button the same fill. it was never invisible because it sits on `background`, but there was no reason for the two destructive buttons to differ.