### PR TITLE
labels... again :D

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/SettingsScreen.kt
@@ -354,8 +354,8 @@ fun SettingsScreen(
                 uriHandler.openUri("https://github.com/you-apps/ClockYou")
             }
             IconPreference(
-                title = stringResource(R.string.app_name), summary = stringResource(
-                    R.string.version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE
+                title = stringResource(R.string.clock_you_version), summary = stringResource(
+                    R.string.version_value, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE
                 ), imageVector = Icons.Default.History
             ) {
                 uriHandler.openUri("https://github.com/you-apps/ClockYou/releases/latest")

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -41,7 +41,6 @@
     <string name="about">حول التطبيق</string>
     <string name="source_code">الكود المصدري</string>
     <string name="source_code_summary">اعرض الكود المصدري للتطبيق</string>
-    <string name="version">الإصدار %1$s (%2$s)</string>
     <string name="timer_service">خدمة المؤقت</string>
     <string name="start_timer">بدء المؤقت؟</string>
     <string name="delete">حذف</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -31,7 +31,6 @@
     <string name="light">İşıqlı</string>
     <string name="source_code">Mənbə kodu</string>
     <string name="source_code_summary">Tətbiq mənbə koduna bax</string>
-    <string name="version">Versiya %1$s (%2$s)</string>
     <string name="analog_clock">Divar saatı</string>
     <string name="digital_clock">Rəqəmsal saat</string>
     <string name="vertical_clock">Şaquli saat</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -40,7 +40,6 @@
     <string name="about">Аб праграме</string>
     <string name="source_code">Зыходны код</string>
     <string name="source_code_summary">Праглядзець зыходны код праграмы</string>
-    <string name="version">Версія %1$s (%2$s)</string>
     <string name="alphabetic">Алфавітны</string>
     <string name="offset">Зрушэнне</string>
     <string name="timer_service">Служба таймера</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -15,7 +15,6 @@
     <string name="silent">Без звук</string>
     <string name="system">Системна</string>
     <string name="source_code_summary">Преглед на изходния код на приложението</string>
-    <string name="version">Издание %1$s (%2$s)</string>
     <string name="analog_clock">Аналогов часовник</string>
     <string name="digital_clock">Цифров часовник</string>
     <string name="vertical_clock">Вертикален часовник</string>

--- a/app/src/main/res/values-bo/strings.xml
+++ b/app/src/main/res/values-bo/strings.xml
@@ -42,7 +42,6 @@
     <string name="dark">མུན་མདོག།</string>
     <string name="source_code">ཐོན་ཁུངས་ཨང་རྟགས།</string>
     <string name="source_code_summary">མཉེན་ཆས་ཀྱི་ཐོན་ཁུངས་ཨང་རྟགས་ལ་གཟིགས།</string>
-    <string name="version">ཐོན་རིམ། %1$s (%2$s)</string>
     <string name="analog_clock">སྣང་མཉེན།</string>
     <string name="digital_clock">ཨང་ལྡན་ཆུ་ཚོད།</string>
     <string name="vertical_clock">གྱེན་དྲང་ཆུ་ཚོད།</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -42,7 +42,6 @@
     <string name="dark">Fosc</string>
     <string name="source_code">Codi font</string>
     <string name="source_code_summary">Visualitza el codi font de l\'aplicació</string>
-    <string name="version">Versió %1$s (%2$s)</string>
     <string name="analog_clock">Rellotge analògic</string>
     <string name="digital_clock">Rellotge digital</string>
     <string name="vertical_clock">Rellotge vertical</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -40,7 +40,6 @@
     <string name="about">O aplikaci</string>
     <string name="source_code_summary">Zobrazit zdrojový kód aplikace</string>
     <string name="source_code">Zdrojový kód</string>
-    <string name="version">Verze %1$s (%2$s)</string>
     <string name="timer_service">Služba časovače</string>
     <string name="start_timer">Spustit časovač\?</string>
     <string name="duration_seconds">Doba: %1$s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -13,7 +13,6 @@
     <string name="dark">Mørk</string>
     <string name="source_code">Kildekode</string>
     <string name="source_code_summary">Se appens kildekode</string>
-    <string name="version">Version %1$s (%2$s)</string>
     <string name="digital_clock">Digitalt ur</string>
     <string name="vertical_clock">Lodret ur</string>
     <string name="delete">Slet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,7 +40,6 @@
     <string name="dark">Dunkel</string>
     <string name="source_code">Quellcode</string>
     <string name="source_code_summary">Den Quellcode der App anzeigen</string>
-    <string name="version">Version %1$s (%2$s)</string>
     <!-- Widgets -->
     <string name="analog_clock">Analoguhr</string>
     <string name="digital_clock">Digitaluhr</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -44,7 +44,6 @@
     <string name="dark">Σκοτεινό</string>
     <string name="source_code">Πηγαίος κώδικας</string>
     <string name="source_code_summary">Προβολή του πηγαίου κώδικα της εφαρμογής</string>
-    <string name="version">Έκδοση %1$s (%2$s)</string>
     <string name="analog_clock">Αναλογικό ρολόι</string>
     <string name="digital_clock">Ψηφιακό ρολόι</string>
     <string name="vertical_clock">Κάθετο ρολόι</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,7 +37,6 @@
     <string name="silent">Silencio</string>
     <string name="default_sound">Predeterminado</string>
     <string name="custom_file">Archivo personalizado</string>
-    <string name="version">Versión %1$s (%2$s)</string>
     <string name="about">Acerca de</string>
     <string name="source_code_summary">Ver el código fuente de la aplicación</string>
     <string name="source_code">Código fuente</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -43,7 +43,6 @@
     <string name="dark">Tume kujundus</string>
     <string name="source_code">Lähtekood</string>
     <string name="source_code_summary">Vaata rakenduse lähtekoodi</string>
-    <string name="version">Versioon %1$s (%2$s)</string>
     <string name="analog_clock">Sihverplaadiga kell</string>
     <string name="digital_clock">Numbritega kell</string>
     <string name="vertical_clock">Püstine kell</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -66,7 +66,6 @@
     <string name="offset">فاصله</string>
     <string name="show_seconds">نمایش ثانیه‌ها</string>
     <string name="source_code_summary">نمایش دستور بن‌مایه‌ی برنامه</string>
-    <string name="version">نگارش %1$s (%2$s)</string>
     <string name="show_timer_quick_selection">نمایش دست‌چین بیدرنگ زمان‌سنج</string>
     <string name="snooze">واپَساندن</string>
     <string name="dismiss">رد‌کردن</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -25,7 +25,6 @@
     <string name="dark">Tumma</string>
     <string name="source_code">Lähdekoodi</string>
     <string name="source_code_summary">Tutustu sovelluksen lähdekoodiin</string>
-    <string name="version">Versio %1$s (%2$s)</string>
     <string name="analog_clock">Analoginen kello</string>
     <string name="digital_clock">Digitaalikello</string>
     <string name="vertical_clock">Pystysuuntainen kello</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -38,7 +38,6 @@
     <string name="about">À propos</string>
     <string name="source_code_summary">Voir le code source de l\'application</string>
     <string name="source_code">Code source</string>
-    <string name="version">Version %1$s (%2$s)</string>
     <string name="custom_file">Fichier personnalisé</string>
     <string name="default_sound">Par défaut</string>
     <string name="behavior">Comportement</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -31,7 +31,6 @@
     <string name="dark">गहरी</string>
     <string name="source_code">सोर्स कोड</string>
     <string name="source_code_summary">ऐप का सोर्स कोड देखें</string>
-    <string name="version">संस्करण %1$s (%2$s)</string>
     <string name="analog_clock">अनुरूप घड़ी</string>
     <string name="digital_clock">डिजिटल घड़ी</string>
     <string name="delete">मिटाएं</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -28,7 +28,6 @@
     <string name="source_code">Codice fonte</string>
     <string name="light">Clar</string>
     <string name="delete">Deler</string>
-    <string name="version">Version %1$s (%2$s)</string>
     <string name="stop">Stoppar</string>
     <string name="sound">Sono</string>
     <string name="clock">Horologio</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -6,7 +6,6 @@
     <string name="search">Cari</string>
     <string name="new_alarm">Buat alarm</string>
     <string name="edit_alarm">Atur alarm</string>
-    <string name="version">Versi %1$s (%2$s)</string>
     <string name="vertical_clock">Jam vertikal</string>
     <string name="vibrate">Getar</string>
     <string name="timer">Timer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -40,7 +40,6 @@
     <string name="about">Informazioni</string>
     <string name="source_code">Codice sorgente</string>
     <string name="source_code_summary">Visualizza il codice sorgente dell\'app</string>
-    <string name="version">Versione %1$s (%2$s)</string>
     <string name="alphabetic">Alfabetico</string>
     <string name="duration_seconds">Durata: %1$s</string>
     <string name="delete">Elimina</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -40,7 +40,6 @@
     <string name="about">על היישומון</string>
     <string name="source_code">קוד מקור</string>
     <string name="source_code_summary">הצגת קוד המקור של היישומון</string>
-    <string name="version">גרסה %1$s‏ (%2$s)</string>
     <string name="timer_service">שירות מתזמן</string>
     <string name="start_timer">להפעיל מתזמן\?</string>
     <string name="duration_seconds">משך: %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -46,7 +46,6 @@
     <string name="dark">ダーク</string>
     <string name="source_code">ソースコード</string>
     <string name="source_code_summary">アプリのソースコードを表示</string>
-    <string name="version">バージョン %1$s (%2$s)</string>
     <!-- Widgets -->
     <string name="analog_clock">アナログ時計</string>
     <string name="digital_clock">デジタル時計</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -44,7 +44,6 @@
     <string name="seconds">Sekunder</string>
     <string name="source_code">Kildekode</string>
     <string name="delete">Slett</string>
-    <string name="version">Versjon %1$s (%2$s)</string>
     <string name="sound">Lyd</string>
     <string name="about">Om</string>
     <string name="start_timer">Start tidsur\?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -26,7 +26,6 @@
     <string name="source_code">Broncode</string>
     <string name="light">Licht</string>
     <string name="delete">Verwijder</string>
-    <string name="version">Versie %1$s (%2$s)</string>
     <string name="stop">Stop</string>
     <string name="sound">Geluid</string>
     <string name="clock">Klok</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -35,7 +35,6 @@
     <string name="light">Jasny</string>
     <string name="dark">Ciemny</string>
     <string name="source_code">Kod źródłowy</string>
-    <string name="version">Wersja %1$s (%2$s)</string>
     <string name="analog_clock">Zegar analogowy</string>
     <string name="vertical_clock">Zegar pionowy</string>
     <string name="source_code_summary">Zobacz kod źródłowy aplikacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,7 +41,6 @@
     <string name="duration_seconds">Duração: %1$s</string>
     <string name="show_seconds">Exibir segundos</string>
     <string name="source_code_summary">Visualizar o código-fonte do aplicativo</string>
-    <string name="version">Versão %1$s (%2$s)</string>
     <string name="delete">Excluir</string>
     <string name="vertical_clock">Relógio vertical</string>
     <string name="appearance">Aparência</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -35,7 +35,6 @@
     <string name="system">Sistema</string>
     <string name="sound">Som</string>
     <string name="source_code_summary">Ver o código fonte da aplicação</string>
-    <string name="version">Versão %1$s (%2$s)</string>
     <string name="source_code">Código-fonte</string>
     <string name="about">Acerca</string>
     <string name="custom_file">Ficheiro personalizado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -40,7 +40,6 @@
     <string name="default_sound">Implicit</string>
     <string name="source_code">Cod sursa</string>
     <string name="source_code_summary">Vizualizați codul sursă al aplicației</string>
-    <string name="version">Versiunea %1$s (%2$s)</string>
     <string name="alphabetic">Alfabetic</string>
     <string name="offset">Compensa</string>
     <string name="timer_service">Serviciu temporizator</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -40,7 +40,6 @@
     <string name="about">О программе</string>
     <string name="source_code">Исходный код</string>
     <string name="source_code_summary">Ознакомьтесь с исходным кодом приложения</string>
-    <string name="version">Версия %1$s (%2$s)</string>
     <string name="alphabetic">Алфавитный</string>
     <string name="offset">Смещение</string>
     <string name="timer_service">Служба таймера</string>

--- a/app/src/main/res/values-ryu/strings.xml
+++ b/app/src/main/res/values-ryu/strings.xml
@@ -46,7 +46,6 @@
     <string name="dark">ダーク</string>
     <string name="source_code">ソースコード</string>
     <string name="source_code_summary">アプリぬソースコードひょうじ</string>
-    <string name="version">バージョン %1$s (%2$s)</string>
     <!-- Widgets -->
     <string name="analog_clock">アナログどぅけいうぅい</string>
     <string name="digital_clock">デジタルどぅけいうぅい</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -45,7 +45,6 @@
     <string name="dark">ᱧᱩᱛ</string>
     <string name="source_code">ᱥᱨᱚᱛ ᱠᱳᱰ</string>
     <string name="source_code_summary">ᱮᱯ ᱨᱮᱭᱟᱜ ᱥᱨᱚᱛ ᱫᱮᱠᱷᱟᱣ ᱢᱮ</string>
-    <string name="version">ᱵᱷᱚᱨᱥᱚᱱ %1$s (%2$s)</string>
     <string name="analog_clock">ᱟᱱᱟᱞᱚᱜᱽ ᱜᱷᱚᱰᱤ</string>
     <string name="digital_clock">ᱰᱤᱡᱤᱴᱟᱞ ᱜᱷᱚᱰᱤ</string>
     <string name="minutes">ᱴᱤᱡ</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -32,7 +32,6 @@
     <string name="start_timer">Покренути тајмер\?</string>
     <string name="duration_seconds">Трајање: %1$s</string>
     <string name="appearance">Изглед</string>
-    <string name="version">Верзија %1$s (%2$s)</string>
     <string name="show_seconds">Прикажи секунде</string>
     <string name="delete">Избриши</string>
     <string name="vertical_clock">Вертикални сат</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -18,7 +18,6 @@
     <string name="source_code">Källkod</string>
     <string name="light">Ljust</string>
     <string name="delete">Ta bort</string>
-    <string name="version">Version %1$s (%2$s)</string>
     <string name="clock">Klocka</string>
     <string name="about">Om</string>
     <string name="stopwatch">Stoppur</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -70,7 +70,6 @@
     <string name="dark">இருள்</string>
     <string name="source_code">மூலக் குறியீடு</string>
     <string name="source_code_summary">பயன்பாட்டின் மூலக் குறியீட்டைக் காண்க</string>
-    <string name="version">பதிப்பு %1$s ( %2$s)</string>
     <string name="analog_clock">அனலாக் கடிகாரம்</string>
     <string name="digital_clock">டிசிட்டல் கடிகாரம்</string>
     <string name="vertical_clock">செங்குத்து கடிகாரம்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -38,7 +38,6 @@
     <string name="custom_file">Özel dosya</string>
     <string name="default_sound">Öntanımlı</string>
     <string name="source_code_summary">Uygulamanın kaynak kodunu görüntüleyin</string>
-    <string name="version">Sürüm %1$s (%2$s)</string>
     <string name="about">Hakkında</string>
     <string name="source_code">Kaynak kodu</string>
     <string name="delete">Sil</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -39,7 +39,6 @@
     <string name="default_sound">Типово</string>
     <string name="about">Про застосунок</string>
     <string name="source_code">Вихідний код</string>
-    <string name="version">Версія %1$s (%2$s)</string>
     <string name="source_code_summary">Переглянути вихідний код застосунку</string>
     <string name="duration_seconds">Тривалість: %1$s</string>
     <string name="timer_service">Послуга таймера</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -57,7 +57,6 @@
     <string name="dark">Tối</string>
     <string name="source_code">Mã nguồn</string>
     <string name="source_code_summary">Xem mã nguồn của ứng dụng</string>
-    <string name="version">Phiên bản %1$s (%2$s)</string>
     <string name="snooze">Ngủ nướng</string>
     <string name="behavior">Hành vi</string>
     <string name="show_timer_quick_selection">Hiển thị lựa chọn nhanh bộ hẹn giờ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -40,7 +40,6 @@
     <string name="source_code">源代码</string>
     <string name="about">关于</string>
     <string name="source_code_summary">查看应用的源代码</string>
-    <string name="version">版本 %1$s (%2$s)</string>
     <string name="timer_service">定时器服务</string>
     <string name="start_timer">启动定时器？</string>
     <string name="duration_seconds">时长：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -28,7 +28,6 @@
     <string name="source_code">原始碼</string>
     <string name="light">亮色</string>
     <string name="delete">刪除</string>
-    <string name="version">版本 %1$s (%2$s)</string>
     <string name="stop">停止</string>
     <string name="sound">聲音</string>
     <string name="clock">時鐘</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,8 @@
     <string name="dark">Dark</string>
     <string name="source_code">Source code</string>
     <string name="source_code_summary">View the app\'s source code</string>
-    <string name="version">Version %1$s (%2$s)</string>
+    <string name="clock_you_version">Clock You version</string>
+    <string name="version_value">%1$s (%2$s)</string>
     <!-- Widgets -->
     <string name="open_app_on_click">Open app on click</string>
     <string name="analog_clock">Analog clock</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     <string name="timer_picker_style">Timer picker style</string>
     <string name="alarm_picker_style">Alarm picker style</string>
     <string name="wheel">Wheel</string>
-    <string name="number_pad">Number pad</string>
+    <string name="number_pad">Numpad</string>
     <string name="delete">Delete</string>
     <string name="behavior">Behavior</string>
     <string name="timeout_after">Timeout after</string>
@@ -93,8 +93,8 @@
     <string name="snooze">Snooze</string>
     <string name="dismiss">Dismiss</string>
     <string name="volume_buttons_during_alarm">Volume buttons during alarm</string>
-    <string name="control_volume">Control volume</string>
-    <string name="do_nothing">Do nothing</string>
+    <string name="control_volume">Volume</string>
+    <string name="do_nothing">Nothing</string>
     <string name="same_time">Same time</string>
     <string name="repeat">Repeat</string>
     <string name="select_snooze_time">Select snooze length</string>


### PR DESCRIPTION
this follows up on the wording pass in #542, and touches labels from #530 and #545.

shorten "Number pad" to "Numpad", "Control volume" to "Volume", "Do nothing" to "Nothing" so the shorter labels also sit better in the segmented buttons I had to widen in #545.

the About entry shows "Clock You" with "Version 1.2.3 (45)" underneath, which reads like a second Source code link until you reach the summary. this titles it "Clock You version" and leaves the value on its own.

that orphans `version` in 38 locales, which lint flags as `ExtraTranslation`, so I removed those in the same commit. the two new strings ship untranslated for the translation workflow to pick up.