### PR TITLE
feat: Add white and black text color options for digital widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.jks

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.LayoutRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -77,6 +78,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -432,23 +434,31 @@ fun ColorSelectSetting(
         ) {
             items(availableColors) { textColor ->
                 val colorValue = Color(textColor.getColorValue(context))
+                val isSelected = currentColor == textColor
 
                 Box(
                     modifier = Modifier
                         .padding(horizontal = 8.dp)
-                        .clip(CircleShape)
                         .size(36.dp)
+                        .clip(CircleShape)
                         .background(colorValue)
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                            shape = CircleShape
+                        )
                         .clickable {
                             onColorSelected(textColor)
-                        }
+                        },
+                    contentAlignment = Alignment.Center
                 ) {
-                    if (currentColor == textColor) {
+                    if (isSelected) {
+                        val checkColor = if (colorValue.luminance() > 0.5f) Color.Black else Color.White
                         Icon(
-                            modifier = Modifier.align(Alignment.Center),
                             imageVector = Icons.Default.Check,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.contentColorFor(colorValue)
+                            tint = checkColor,
+                            modifier = Modifier.size(20.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/DigitalClockWidget.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/DigitalClockWidget.kt
@@ -86,11 +86,9 @@ class DigitalClockWidget : TextWidgetProvider() {
 
             val timeColor = options.timeColor.getColorValue(context)
             val dateColor = options.dateColor.getColorValue(context)
-            if (timeColor != -1 && dateColor != -1) {
-                setTextColor(dateId, dateColor)
-                setTextColor(cityId, dateColor)
-                setTextColor(timeId, timeColor)
-            }
+            setTextColor(dateId, dateColor)
+            setTextColor(cityId, dateColor)
+            setTextColor(timeId, timeColor)
 
             setInt(R.id.frameLayout, "setBackgroundResource", backgroundResource)
 

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/VerticalClockWidget.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/VerticalClockWidget.kt
@@ -97,12 +97,10 @@ class VerticalClockWidget : TextWidgetProvider() {
 
             val timeColor = options.timeColor.getColorValue(context)
             val dateColor = options.dateColor.getColorValue(context)
-            if (timeColor != -1 && dateColor != -1) {
-                setTextColor(hoursId, timeColor)
-                setTextColor(minutesId, timeColor)
-                setTextColor(dateId, dateColor)
-                setTextColor(cityId, dateColor)
-            }
+            setTextColor(hoursId, timeColor)
+            setTextColor(minutesId, timeColor)
+            setTextColor(dateId, dateColor)
+            setTextColor(cityId, dateColor)
 
             setInt(R.id.frameLayout, "setBackgroundResource", backgroundResource)
 

--- a/app/src/main/java/com/bnyro/clock/util/widgets/TextColor.kt
+++ b/app/src/main/java/com/bnyro/clock/util/widgets/TextColor.kt
@@ -3,14 +3,21 @@ package com.bnyro.clock.util.widgets
 import android.content.Context
 import com.google.android.material.color.MaterialColors
 
-enum class TextColor(val attrInt: Int) {
+enum class TextColor(val attrInt: Int, val directColor: Int? = null) {
     Primary(android.R.attr.colorPrimary),
     PrimaryDark(android.R.attr.colorPrimaryDark),
     Secondary(com.google.android.material.R.attr.colorSecondary),
     SecondaryVariant(com.google.android.material.R.attr.colorSecondaryVariant),
-    Tertiary(com.google.android.material.R.attr.colorTertiary)
+    Tertiary(com.google.android.material.R.attr.colorTertiary),
+    White(android.R.color.white, android.graphics.Color.WHITE),
+    Black(android.R.color.black, android.graphics.Color.BLACK);
+
+    constructor(attrInt: Int) : this(attrInt, null)
 }
 
 fun TextColor.getColorValue(context: Context): Int {
-    return MaterialColors.getColor(context, this.attrInt, -1)
+    if (this.directColor != null) {
+        return this.directColor
+    }
+    return MaterialColors.getColor(context, this.attrInt, 0)
 }


### PR DESCRIPTION
### Summary
Adds pure **White** and **Black** text color options for both date and time in digital clock widgets (`DigitalClockWidget` and `VerticalClockWidget`), giving users high-contrast monochrome choices alongside dynamic Material You theme colors.

Closes #528

---

### Technical Details & Fixes

1. **Direct Colors in `TextColor`**:
   - Added `White` (`Color.WHITE`) and `Black` (`Color.BLACK`) to [`TextColor.kt`](file:///c:/Users/manju/Downloads/Projects/ClockYou/app/src/main/java/com/bnyro/clock/util/widgets/TextColor.kt) with direct `@ColorInt` support so static colors are returned directly without needing theme attribute resolution.

2. **Fix for `Color.WHITE` Application in RemoteViews**:
   - Previously, [`DigitalClockWidget.kt`](file:///c:/Users/manju/Downloads/Projects/ClockYou/app/src/main/java/com/bnyro/clock/presentation/widgets/DigitalClockWidget.kt) and [`VerticalClockWidget.kt`](file:///c:/Users/manju/Downloads/Projects/ClockYou/app/src/main/java/com/bnyro/clock/presentation/widgets/VerticalClockWidget.kt) guarded `setTextColor` with `if (timeColor != -1 && dateColor != -1)` because `-1` was used as a fallback sentinel when resolving theme attributes.
   - However, in Android ARGB format (32-bit signed int), pure **White** (`0xFFFFFFFF`) is literally `-1` (`Color.WHITE == -1`), which caused pure white to be treated as an unresolved attribute and skipped.
   - Removed this check so direct colors (and standard theme attributes) are always applied as expected to the widget views.

3. **Color Picker Contrast & Swatch Outlines**:
   - Added subtle borders around color swatches in [`ClockWidgetConfig.kt`](file:///c:/Users/manju/Downloads/Projects/ClockYou/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt) so white swatches on light backgrounds and black swatches on dark/AMOLED backgrounds remain easily distinguishable.
   - Used luminance-based checkmark tinting so the selection indicator is always clearly visible on any swatch color.

---

### Verification
- [x] `./gradlew assembleDebug` passed
- [x] Installed and tested on device (`./gradlew installDebug`)
- [x] Verified White, Black, and dynamic theme colors apply correctly across `DigitalClockWidget` and `VerticalClockWidget`