### PR TITLE
offer the "Default" sound option in the ringtone picker

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/features/RingtonePickerDialog.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/features/RingtonePickerDialog.kt
@@ -1,6 +1,7 @@
 package com.bnyro.clock.presentation.features
 
 import android.R
+import android.media.RingtoneManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.clickable
@@ -41,7 +42,7 @@ import com.bnyro.clock.util.extensions.getContentFileName
 fun RingtonePickerDialog(
     onDismissRequest: () -> Unit,
     bottomContent: @Composable ColumnScope.() -> Unit = {},
-    onSelection: (String, Uri) -> Unit
+    onSelection: (String?, Uri?) -> Unit
 ) {
     val context = LocalContext.current
     val ringingToneModel: RingingToneModel = viewModel()
@@ -93,23 +94,27 @@ fun RingtonePickerDialog(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        items(ringingToneModel.sounds) { (title, uri) ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(10.dp))
-                                    .clickable {
-                                        onSelection.invoke(title, uri)
-                                        onDismissRequest.invoke()
-                                    }
-                                    .padding(horizontal = 10.dp, vertical = 2.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(title)
-                                Spacer(modifier = Modifier.weight(1f))
-                                ClickableIcon(imageVector = Icons.Default.NotificationsActive) {
-                                    ringingToneModel.playRingingTone(context, uri)
+                        item {
+                            SoundItem(
+                                title = stringResource(com.bnyro.clock.R.string.default_sound),
+                                onPlay = {
+                                    ringingToneModel.playRingingTone(
+                                        context,
+                                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+                                    )
                                 }
+                            ) {
+                                onSelection.invoke(null, null)
+                                onDismissRequest.invoke()
+                            }
+                        }
+                        items(ringingToneModel.sounds) { (title, uri) ->
+                            SoundItem(
+                                title = title,
+                                onPlay = { ringingToneModel.playRingingTone(context, uri) }
+                            ) {
+                                onSelection.invoke(title, uri)
+                                onDismissRequest.invoke()
                             }
                         }
                     }
@@ -121,4 +126,24 @@ fun RingtonePickerDialog(
             }
         }
     )
+}
+
+@Composable
+private fun SoundItem(
+    title: String,
+    onPlay: () -> Unit,
+    onSelect: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(onClick = onSelect)
+            .padding(horizontal = 10.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(title)
+        Spacer(modifier = Modifier.weight(1f))
+        ClickableIcon(imageVector = Icons.Default.NotificationsActive, onClick = onPlay)
+    }
 }

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarmpicker/components/AlarmSettingsSheet.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarmpicker/components/AlarmSettingsSheet.kt
@@ -339,7 +339,7 @@ fun AlarmPicker(
         RingtonePickerDialog(onDismissRequest = {
             showRingtoneDialog = false
         }) { title, uri ->
-            soundUri = uri.toString()
+            soundUri = uri?.toString()
             soundName = title
         }
     }

--- a/app/src/main/java/com/bnyro/clock/util/RingtoneHelper.kt
+++ b/app/src/main/java/com/bnyro/clock/util/RingtoneHelper.kt
@@ -5,14 +5,6 @@ import android.media.RingtoneManager
 import android.net.Uri
 
 class RingtoneHelper {
-    fun getDefault(context: Context): Uri? {
-        return RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_ALARM)
-            ?: RingtoneManager.getActualDefaultRingtoneUri(
-                context,
-                RingtoneManager.TYPE_NOTIFICATION
-            )
-    }
-
     fun getAvailableSounds(context: Context): Map<String, Uri> {
         val manager = RingtoneManager(context)
         manager.setType(RingtoneManager.TYPE_RINGTONE)

--- a/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
+++ b/app/src/main/java/com/bnyro/clock/util/services/TimerService.kt
@@ -35,7 +35,6 @@ import com.bnyro.clock.domain.model.TimerObject
 import com.bnyro.clock.domain.model.WatchState
 import com.bnyro.clock.ui.MainActivity
 import com.bnyro.clock.util.NotificationHelper
-import com.bnyro.clock.util.RingtoneHelper
 
 import java.util.Timer
 import java.util.TimerTask


### PR DESCRIPTION
once an alarm or timer uses another sound, the picker has no way to put it back on the system default without clearing the app's data.

this adds Default at the top of the sound list. it can be previewed like the other sounds, and selecting it stores no fixed ringtone so Android resolves whichever sound is currently configured as the system default when the alarm or timer rings.

<img width="650" height="1280" alt="image" src="https://github.com/user-attachments/assets/ad2f6834-07b6-4cbf-8063-a42bd83bf663" />

I also removed the unused default ringtone helper. the alarm and timer services already resolve the default themselves, and the helper used a different fallback from them anyway.