### PR TITLE
remove orphaned translations left after #561

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -155,11 +155,9 @@
     <string name="timer_use_big_start">استخدام زر البداية الكبير</string>
     <string name="upcoming_alarm_content">سينطلق في %1$s</string>
     <string name="skip">تخطي</string>
-    <string name="custom_rgb_color">لون RGB مخصص</string>
     <string name="red">أحمر</string>
     <string name="green">أخضر</string>
     <string name="blue">أزرق</string>
-    <string name="apply">تطبيق</string>
     <string name="cancel">إلغاء</string>
     <string name="clock_you_version">إصدار Clock You</string>
     <string name="general">عام</string>
@@ -194,7 +192,6 @@
     <string name="missed_alarms">المنبهات الفائتة</string>
     <string name="alarm_picker_style">نمط المنتقي</string>
     <string name="timer_picker_style">نمط المنتقي</string>
-    <string name="wheel">عجلة</string>
     <string name="number_pad">لوحة الأرقام</string>
     <string name="paused_stopwatch">ساعة التوقيف مُتوقفة مؤقتًا</string>
     <string name="running_stopwatch">ساعة التوقيف قيد التشغيل</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -153,11 +153,9 @@
     <string name="finished_named_timer">Minutnik %1$s zakończył odliczanie</string>
     <string name="running_stopwatch">Stoper uruchomiony</string>
     <string name="paused_stopwatch">Stoper wstrzymany</string>
-    <string name="custom_rgb_color">Niestandardowy kolor RGB</string>
     <string name="red">Czerwony</string>
     <string name="green">Zielony</string>
     <string name="blue">Niebieski</string>
-    <string name="apply">Zastosuj</string>
     <string name="cancel">Anuluj</string>
     <string name="general">Ogólne</string>
     <string name="clock_you_version">Wersja Clock You</string>
@@ -167,7 +165,6 @@
     <string name="open_app_on_click">Otwórz aplikację po kliknięciu</string>
     <string name="timer_picker_style">Styl menu wyboru</string>
     <string name="alarm_picker_style">Styl menu wyboru</string>
-    <string name="wheel">Pokrętło</string>
     <string name="number_pad">Klawiatura numeryczna</string>
     <string name="timeout_after">Limit czasu po</string>
     <string name="select_alarm_timeout">Wybierz czas trwania alarmu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -141,11 +141,9 @@
     <string name="finished_named_timer">%1$s 定时器已结束</string>
     <string name="running_stopwatch">秒表正在运行</string>
     <string name="paused_stopwatch">秒表已暂停</string>
-    <string name="custom_rgb_color">自定义 RGB 颜色</string>
     <string name="red">红色</string>
     <string name="green">绿色</string>
     <string name="blue">蓝色</string>
-    <string name="apply">应用</string>
     <string name="cancel">取消</string>
     <string name="general">常规</string>
     <string name="clock_you_version">Clock You 版本</string>
@@ -155,7 +153,6 @@
     <string name="open_app_on_click">点击时打开应用</string>
     <string name="timer_picker_style">选择器样式</string>
     <string name="alarm_picker_style">选择器样式</string>
-    <string name="wheel">滚轮</string>
     <string name="number_pad">数字键盘</string>
     <string name="timeout_after">超时时间</string>
     <string name="select_alarm_timeout">选择闹钟超时时间</string>


### PR DESCRIPTION
this follows up on #561. `custom_rgb_color`, `apply`, and `wheel` no longer exist in the default strings, but their Arabic, Polish, and Simplified Chinese translations are still there.

release lint treats each one as `ExtraTranslation`, so this removes those nine orphaned translations.