### PR TITLE
Standardize Colors for Look Consistency

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/components/ScrollWheel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/components/ScrollWheel.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import com.bnyro.clock.ui.theme.primaryFade
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,7 +37,7 @@ fun ScrollWheel(
     label: (Int) -> String = { String.format("%02d", it) }
 ) {
     val primary = MaterialTheme.colorScheme.primary
-    val primaryMuted = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+    val primaryMuted = MaterialTheme.colorScheme.primaryFade
     val hapticFeedback = LocalHapticFeedback.current
     val state = rememberPagerState(initialPage = maxValue * 100 + value - offset) {
         maxValue * 200

--- a/app/src/main/java/com/bnyro/clock/presentation/components/SwitchWithDivider.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/components/SwitchWithDivider.kt
@@ -10,12 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,13 +67,13 @@ fun SwitchWithDivider(
                     )
                 }
             }
-            HorizontalDivider(
+            VerticalDivider(
                 modifier = Modifier
                     .height(32.dp)
                     .padding(horizontal = 8.dp)
                     .width(1.dp)
                     .align(Alignment.CenterVertically),
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                color = MaterialTheme.colorScheme.outlineVariant
             )
             Switch(
                 checked = isChecked,

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
@@ -107,7 +107,7 @@ fun AlarmScreen(
                             modifier = Modifier
                                 .padding(vertical = 12.dp)
                                 .width(1.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
+                            color = MaterialTheme.colorScheme.outlineVariant
                         )
                         Box(
                             modifier = Modifier

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
+import com.bnyro.clock.ui.theme.primaryFade
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -107,7 +108,7 @@ fun AlarmScreen(
                             modifier = Modifier
                                 .padding(vertical = 12.dp)
                                 .width(1.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant
+                            color = MaterialTheme.colorScheme.primaryFade
                         )
                         Box(
                             modifier = Modifier

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmItem.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmItem.kt
@@ -98,7 +98,7 @@ fun AlarmItem(
                         if (isSelected) {
                             Modifier.border(
                                 width = 2.dp,
-                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                color = MaterialTheme.colorScheme.primary,
                                 shape = cardShape
                             )
                         } else {

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/WidgetsScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/WidgetsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
+import com.bnyro.clock.ui.theme.primarySoft
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -173,7 +174,7 @@ fun WidgetsScreen(
                         imageVector = Icons.Rounded.Widgets,
                         contentDescription = null,
                         modifier = Modifier.size(72.dp),
-                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                        tint = MaterialTheme.colorScheme.primarySoft
                     )
                     Spacer(Modifier.height(16.dp))
                     Text(

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/TimerItem.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/timer/components/TimerItem.kt
@@ -79,7 +79,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                val colorTextLowerAlpha = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                val mutedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
 
                 Column(modifier = Modifier.weight(1f)) {
                     val titleText = obj.label.value ?: if (isFinished) stringResource(R.string.timer_finished) else null
@@ -88,7 +88,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                             text = label,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Normal,
-                            color = colorTextLowerAlpha,
+                            color = mutedContentColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -117,7 +117,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                                     modifier = Modifier.size(16.dp),
                                     imageVector = Icons.Default.Notifications,
                                     contentDescription = null,
-                                    tint = colorTextLowerAlpha
+                                    tint = mutedContentColor
                                 )
                                 Spacer(modifier = Modifier.width(5.dp))
                                 Text(
@@ -126,7 +126,7 @@ fun TimerItem(obj: TimerObject, timerModel: TimerModel) {
                                         ZonedDateTime.now().plusHours(hours.toLong())
                                             .plusMinutes(minutes.toLong()).plusSeconds(seconds.toLong())
                                     ),
-                                    color = colorTextLowerAlpha,
+                                    color = mutedContentColor,
                                     style = MaterialTheme.typography.bodyMedium
                                 )
                             }

--- a/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/widgets/ClockWidgetConfig.kt
@@ -518,7 +518,7 @@ fun ColorSelectSetting(
                         .background(colorValue)
                         .border(
                             width = 1.dp,
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                            color = MaterialTheme.colorScheme.outlineVariant,
                             shape = CircleShape
                         )
                         .clickable {

--- a/app/src/main/java/com/bnyro/clock/ui/theme/Color.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/theme/Color.kt
@@ -1,6 +1,17 @@
 package com.bnyro.clock.ui.theme
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
+
+/**
+ * [ColorScheme.primary] at the weight a control takes when it sits behind the one in focus.
+ */
+val ColorScheme.primaryFade: Color get() = primary.copy(alpha = 0.3f)
+
+/**
+ * [ColorScheme.primary] at the weight a control takes when it carries no focus of its own.
+ */
+val ColorScheme.primarySoft: Color get() = primary.copy(alpha = 0.6f)
 
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)

--- a/app/src/main/java/com/bnyro/clock/ui/theme/Color.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/theme/Color.kt
@@ -12,11 +12,3 @@ val ColorScheme.primaryFade: Color get() = primary.copy(alpha = 0.3f)
  * [ColorScheme.primary] at the weight a control takes when it carries no focus of its own.
  */
 val ColorScheme.primarySoft: Color get() = primary.copy(alpha = 0.6f)
-
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)


### PR DESCRIPTION
Sorry to hear your ssd broke @Elektron123 , hopefully everything is okay.

`SwitchWithDivider` draws its divider with `HorizontalDivider`, which appends `.fillMaxWidth().height(thickness)` after the modifier it's given. the call site asks for `.width(1.dp).height(32.dp)`, so those get overridden and the line collapses. on a Pixel 6 it comes out as a 3×3 dot instead of the 84px line it should be, which is why nobody ever noticed the colour was wrong too.

`VerticalDivider` sizes the other way round, so it's a straight swap. the divider matters here because the row has two separate tap targets, the text opens the ringtone/vibration/snooze dialog and the switch toggles it, and right now nothing tells you that.

<img width="1306" height="1064" alt="image" src="https://github.com/user-attachments/assets/c0fbedfd-f996-4bfd-b639-1d65191aef9b" />

<img width="1380" height="966" alt="image" src="https://github.com/user-attachments/assets/ef3656a8-c795-415d-b532-9171a5319cc3" />

while I was in there I took the colours around it from the role that already describes them instead of a faded copy of a different one:

| where | was | now |
|---|---|---|
| switch row divider | `onSurface` @ 30% | `outlineVariant` |
| selected alarm outline | `primary` @ 60% | `primary` |
| timer's secondary line | `onBackground` @ 70% | `onSurfaceVariant` |
| widget colour swatch border | `outlineVariant` @ 50% | `outlineVariant` |

the swatch border already used `outlineVariant`, just at half strength, which left it lighter than the "Pick custom color" button sitting right under it, and those now match.

the app also fades `primary` to two fixed weights in three places, each written out at the call site, so those are named in the theme now:

```kotlin
val ColorScheme.primaryFade: Color get() = primary.copy(alpha = 0.3f)
val ColorScheme.primarySoft: Color get() = primary.copy(alpha = 0.6f)
```

`primaryFade` is the scroll wheel's unselected rows, `primarySoft` is the icon on the empty widgets screen. neither renders any differently, it's the same value read from one place.

the `+ | ^` divider takes the fade as well. it was `onSurfaceVariant` @ 20%, and I first moved it to `outlineVariant` with the other dividers, but that's a neutral grey meant for dividers on a surface, and this one sits on a filled `primaryContainer` so it came out looking foreign, worst in dark. the fade keeps it in the button's own colour family.

<img width="882" height="688" alt="image" src="https://github.com/user-attachments/assets/43d9bdae-26cd-4564-8a10-a623bacc1a6f" />

<img width="1746" height="598" alt="image" src="https://github.com/user-attachments/assets/40bf0583-b329-428a-a28a-34b407b96b9d" />

<img width="1330" height="568" alt="image" src="https://github.com/user-attachments/assets/0bf0e0ab-56ed-4840-a4b4-add3167bd7db" />

lastly `Color.kt` still had `Purple80` through `Pink40` from the project template. nothing has referenced them since the app was scaffolded, so they're gone and the file is just the two weights now.