### PR TITLE
open the advanced alarm from a menu on the chevron again

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
@@ -113,10 +113,22 @@ fun AlarmScreen(
                             modifier = Modifier
                                 .fillMaxHeight()
                                 .width(FAB_SIZE / 2)
-                                .clickable { onAlarm.invoke(0L, true) },
+                                .clickable { showAlarmKinds = true },
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(Icons.Rounded.ExpandLess, null)
+                            DropdownMenu(
+                                expanded = showAlarmKinds,
+                                onDismissRequest = { showAlarmKinds = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.add_advanced_alarm)) },
+                                    onClick = {
+                                        showAlarmKinds = false
+                                        onAlarm.invoke(0L, true)
+                                    }
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up to #556.

The split add button ended up with the chevron half navigating straight to the advanced alarm editor, so the `Icons.Rounded.ExpandLess` affordance now promises a menu it never shows, and there is nowhere to put a second alarm kind if one is ever added.

This restores the `DropdownMenu` on that half, exactly as it was before the last commit on #556. The split-button look, the divider inset and its colour are all left as they are — only the chevron's behaviour changes back.

It also puts `showAlarmKinds` and `R.string.add_advanced_alarm` back to use; both are currently dead on `main`.