### PR TITLE
Add "Starts week on" settings (and improve weekly calculations)

### DIFF
--- a/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
@@ -5,7 +5,6 @@ import com.bnyro.clock.R
 import java.time.DayOfWeek
 
 enum class WeekStart(@StringRes val resId: Int, val dayOfWeek: DayOfWeek) {
-    FRIDAY(R.string.friday, DayOfWeek.FRIDAY),
     SATURDAY(R.string.saturday, DayOfWeek.SATURDAY),
     SUNDAY(R.string.sunday, DayOfWeek.SUNDAY),
     MONDAY(R.string.monday, DayOfWeek.MONDAY)

--- a/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
@@ -5,6 +5,7 @@ import com.bnyro.clock.R
 import java.time.DayOfWeek
 
 enum class WeekStart(@StringRes val resId: Int, val dayOfWeek: DayOfWeek) {
+    FRIDAY(R.string.friday, DayOfWeek.FRIDAY),
     SATURDAY(R.string.saturday, DayOfWeek.SATURDAY),
     SUNDAY(R.string.sunday, DayOfWeek.SUNDAY),
     MONDAY(R.string.monday, DayOfWeek.MONDAY)

--- a/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
+++ b/app/src/main/java/com/bnyro/clock/domain/model/WeekStart.kt
@@ -1,0 +1,12 @@
+package com.bnyro.clock.domain.model
+
+import androidx.annotation.StringRes
+import com.bnyro.clock.R
+import java.time.DayOfWeek
+
+enum class WeekStart(@StringRes val resId: Int, val dayOfWeek: DayOfWeek) {
+    FRIDAY(R.string.friday, DayOfWeek.FRIDAY),
+    SATURDAY(R.string.saturday, DayOfWeek.SATURDAY),
+    SUNDAY(R.string.sunday, DayOfWeek.SUNDAY),
+    MONDAY(R.string.monday, DayOfWeek.MONDAY)
+}

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmCard.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmCard.kt
@@ -134,7 +134,7 @@ fun AlarmCard(
 
                             else -> {
                                 val daysOfWeek = remember {
-                                    AlarmHelper.getDaysOfWeekByLocale(context)
+                                    AlarmHelper.getDaysOfWeekForDisplay(context)
                                 }
                                 daysOfWeek.forEach { (day, index) ->
                                     val enabled = alarm.days.contains(index)

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmFilterSection.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/components/AlarmFilterSection.kt
@@ -115,7 +115,7 @@ fun WeekDayRow(weekDays: List<Int>, onClickWeekDay: (List<Int>) -> Unit) {
             .padding(20.dp),
         horizontalArrangement = Arrangement.Start
     ) {
-        val daysOfWeek = remember { AlarmHelper.getDaysOfWeekByLocale(context) }
+        val daysOfWeek = remember { AlarmHelper.getDaysOfWeekForDisplay(context) }
         val chosenDays = remember { weekDays.toMutableList() }
 
         Icon(

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarmpicker/components/RecurrencePicker.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarmpicker/components/RecurrencePicker.kt
@@ -539,7 +539,7 @@ private fun WeekdaySelector(chosenDays: MutableList<Int>) {
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         val daysOfWeek = remember {
-            AlarmHelper.getDaysOfWeekByLocale(context)
+            AlarmHelper.getDaysOfWeekForDisplay(context)
         }
 
         daysOfWeek.forEach { (day, index) ->

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/SettingsScreen.kt
@@ -42,6 +42,7 @@ import com.bnyro.clock.BuildConfig
 import com.bnyro.clock.R
 import com.bnyro.clock.domain.model.PickerStyle
 import com.bnyro.clock.domain.model.VolumeButtonAction
+import com.bnyro.clock.domain.model.WeekStart
 import com.bnyro.clock.navigation.NavRoutes
 import com.bnyro.clock.navigation.homeRoutes
 import com.bnyro.clock.presentation.components.ClickableIcon
@@ -197,6 +198,16 @@ fun SettingsScreen(
                 val key = selectedKey as String
                 val currentState = Preferences.instance.getBoolean("show_tab_$key", true)
                 settingsModel.toggleTab(key, !currentState)
+            }
+
+            ButtonGroupPref(
+                title = stringResource(R.string.start_week_on),
+                options = WeekStart.entries.map { stringResource(it.resId) },
+                values = WeekStart.entries,
+                currentValue = settingsModel.weekStart
+            ) {
+                settingsModel.weekStart = it
+                Preferences.edit { putString(Preferences.weekStartKey, it.name) }
             }
 
             HorizontalDivider(

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
@@ -17,6 +17,7 @@ import com.bnyro.clock.App
 import com.bnyro.clock.R
 import com.bnyro.clock.domain.model.Alarm
 import com.bnyro.clock.domain.model.PickerStyle
+import com.bnyro.clock.domain.model.WeekStart
 import com.bnyro.clock.domain.usecase.CreateUpdateDeleteAlarmUseCase
 import com.bnyro.clock.navigation.HomeRoutes
 import com.bnyro.clock.navigation.homeRoutes
@@ -31,6 +32,7 @@ import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
+import java.util.GregorianCalendar
 import com.bnyro.clock.domain.model.VolumeButtonAction
 
 class SettingsModel : ViewModel() {
@@ -67,6 +69,13 @@ class SettingsModel : ViewModel() {
                 PickerStyle.WHEEL.name
             ) ?: PickerStyle.WHEEL.name
         )
+    )
+    var weekStart by mutableStateOf(
+        Preferences.instance.getString(Preferences.weekStartKey, null)
+            ?.let { WeekStart.valueOf(it) }
+            ?: WeekStart.entries.first {
+                it.dayOfWeek.value % 7 == GregorianCalendar().firstDayOfWeek - 1
+            }
     )
     var customColor by mutableStateOf(
         Preferences.instance.getInt(Preferences.customColorKey, catpucchinLatte.first())

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
@@ -73,9 +73,9 @@ class SettingsModel : ViewModel() {
     var weekStart by mutableStateOf(
         Preferences.instance.getString(Preferences.weekStartKey, null)
             ?.let { WeekStart.valueOf(it) }
-            ?: WeekStart.entries.first {
+            ?: WeekStart.entries.firstOrNull {
                 it.dayOfWeek.value % 7 == GregorianCalendar().firstDayOfWeek - 1
-            }
+            } ?: WeekStart.SATURDAY
     )
     var customColor by mutableStateOf(
         Preferences.instance.getInt(Preferences.customColorKey, catpucchinLatte.first())

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/settings/model/SettingsModel.kt
@@ -73,9 +73,9 @@ class SettingsModel : ViewModel() {
     var weekStart by mutableStateOf(
         Preferences.instance.getString(Preferences.weekStartKey, null)
             ?.let { WeekStart.valueOf(it) }
-            ?: WeekStart.entries.firstOrNull {
+            ?: WeekStart.entries.first {
                 it.dayOfWeek.value % 7 == GregorianCalendar().firstDayOfWeek - 1
-            } ?: WeekStart.SATURDAY
+            }
     )
     var customColor by mutableStateOf(
         Preferences.instance.getInt(Preferences.customColorKey, catpucchinLatte.first())

--- a/app/src/main/java/com/bnyro/clock/util/AlarmHelper.kt
+++ b/app/src/main/java/com/bnyro/clock/util/AlarmHelper.kt
@@ -25,11 +25,9 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
-import java.time.temporal.WeekFields
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
-import java.util.Locale
 import kotlin.time.Duration.Companion.milliseconds
 //schweiny ass file
 object AlarmHelper {
@@ -265,13 +263,8 @@ object AlarmHelper {
             }
 
             RepeatUnit.WEEK -> {
-                val firstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek
-                val startWeek = startDate.with(TemporalAdjusters.previousOrSame(firstDayOfWeek))
-                val elapsed = ChronoUnit.WEEKS.between(
-                    startWeek,
-                    from.with(TemporalAdjusters.previousOrSame(firstDayOfWeek))
-                ) / interval
-                generateSequence(startWeek.plusWeeks(elapsed * interval)) { it.plusWeeks(interval) }
+                val elapsed = ChronoUnit.WEEKS.between(startDate, from) / interval
+                generateSequence(startDate.plusWeeks(elapsed * interval)) { it.plusWeeks(interval) }
             }
 
             RepeatUnit.MONTH, RepeatUnit.YEAR -> {

--- a/app/src/main/java/com/bnyro/clock/util/AlarmHelper.kt
+++ b/app/src/main/java/com/bnyro/clock/util/AlarmHelper.kt
@@ -14,6 +14,7 @@ import com.bnyro.clock.domain.model.Alarm
 import com.bnyro.clock.domain.model.RepeatAnchor
 import com.bnyro.clock.domain.model.Permission
 import com.bnyro.clock.domain.model.RepeatUnit
+import com.bnyro.clock.domain.model.WeekStart
 import com.bnyro.clock.ui.MainActivity
 import com.bnyro.clock.util.receivers.AlarmReceiver
 import com.bnyro.clock.util.receivers.PreAlarmReceiver
@@ -348,12 +349,14 @@ object AlarmHelper {
     }
     /**
      * @return the days of the week mapped to an index 0-Sunday, 1-Monday, ..., 6-Saturday.
-     * The list order will match the user preferred days of the week order.
+     * The list order is only for presentation and follows the user's preference or locale without
+     * changing an alarm's recurrence.
      */
-
-    fun getDaysOfWeekByLocale(context: Context): List<Pair<String, Int>> {
+    fun getDaysOfWeekForDisplay(context: Context): List<Pair<String, Int>> {
         val availableDays = context.resources.getStringArray(R.array.available_days).toList()
-        val firstDayIndex = GregorianCalendar().firstDayOfWeek - 1
+        val firstDayIndex = Preferences.instance.getString(Preferences.weekStartKey, null)
+            ?.let { WeekStart.valueOf(it).dayOfWeek.value % DAYS_PER_WEEK }
+            ?: GregorianCalendar().firstDayOfWeek - 1
         val daysWithIndex = availableDays.mapIndexed { index, s -> s to index }
         return daysWithIndex.subList(firstDayIndex, 7) + daysWithIndex.subList(0, firstDayIndex)
     }

--- a/app/src/main/java/com/bnyro/clock/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/clock/util/Preferences.kt
@@ -21,6 +21,7 @@ object Preferences {
     const val customColorKey = "customColor"
     const val colorThemeKey = "colorTheme"
     const val startTabKey = "startTab"
+    const val weekStartKey = "weekStart"
     const val volumeButtonActionKey = "volumeButtonAction"
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,7 +145,6 @@
     <string name="plus_button_position">Plus button position</string>
     <string name="start_tab">Start tab</string>
     <string name="start_week_on">Start week on</string>
-    <string name="friday">Friday</string>
     <string name="saturday">Saturday</string>
     <string name="sunday">Sunday</string>
     <string name="monday">Monday</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,11 @@
     <string name="color_scheme">Color scheme</string>
     <string name="plus_button_position">Plus button position</string>
     <string name="start_tab">Start tab</string>
+    <string name="start_week_on">Start week on</string>
+    <string name="friday">Friday</string>
+    <string name="saturday">Saturday</string>
+    <string name="sunday">Sunday</string>
+    <string name="monday">Monday</string>
     <string name="from">From</string>
     <string name="to">To</string>
     <plurals name="hour_offset_positive">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="plus_button_position">Plus button position</string>
     <string name="start_tab">Start tab</string>
     <string name="start_week_on">Start week on</string>
+    <string name="friday">Friday</string>
     <string name="saturday">Saturday</string>
     <string name="sunday">Sunday</string>
     <string name="monday">Monday</string>

--- a/app/src/test/java/com/bnyro/clock/AlarmHelperTest.kt
+++ b/app/src/test/java/com/bnyro/clock/AlarmHelperTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.LocalDate
 import java.util.Calendar
+import java.util.Locale
 
 class AlarmHelperTest {
     private fun recurringAlarm(
@@ -88,6 +89,23 @@ class AlarmHelperTest {
             listOf(LocalDate.of(2099, 1, 5), LocalDate.of(2099, 1, 7), LocalDate.of(2099, 1, 19)),
             occurrences(alarm, 3)
         )
+    }
+
+    @Test
+    fun weeklyAlarmAnchorsItsSevenDayRunsOnItsStartDateInEveryLocale() {
+        val locale = Locale.getDefault()
+        val alarm = recurringAlarm(LocalDate.of(2099, 1, 7), RepeatUnit.WEEK, repeatInterval = 2)
+            .apply { days = listOf(0) }
+        val expected = listOf(LocalDate.of(2099, 1, 11), LocalDate.of(2099, 1, 25))
+
+        try {
+            Locale.setDefault(Locale.US)
+            assertEquals(expected, occurrences(alarm, 2))
+            Locale.setDefault(Locale.UK)
+            assertEquals(expected, occurrences(alarm, 2))
+        } finally {
+            Locale.setDefault(locale)
+        }
     }
 
     @Test


### PR DESCRIPTION
the week can start wherever the user wants it to *look* like it starts, but an alarm's schedule has to mean the same thing on every phone (for advanced alarms).

## The Setting

<img width="434" height="286" alt="image" src="https://github.com/user-attachments/assets/115cd28a-2098-4dcf-87c5-d182d6913b7d" />

as much as I want the user to get used to what their locale say what their first day of the week should be (based on CLDR data), I discovered that it only follows locale only if I change my phone's language to my language for it to take effect, which unfortunately I use en-US which has the locale set to Sunday. the country I live in, Malaysia, Monday is the first day of the week, and me personally too, but I shouldn't have to change my phone's language to my language.

so settings gains a "Start week on" row under General, which defaults on whatever the locale already says, so nothing changes for anyone who doesn't look for it. the alarm card's circles, the filter's weekday row, and the recurrence picker's selector all order themselves from it.

this is purely presentation only. the ordering helper is named `getDaysOfWeekForDisplay` and documented as such, weekday identities stay Sunday 0 through Saturday 6. an unset preference still follows the locale's own first day, including Friday for the Maldives, which is the one territory on earth that starts its week there (based on CLDR).

## Consistent Week Anchor for Advanced Alarms

weekly repetition runs were snapped to the device's week boundary `WeekFields.of(Locale.getDefault()).firstDayOfWeek`. now, they begin on the alarm's `startDate` so the first run is `startDate` through six days on, and each later run another `repeatInterval` weeks out. the scheduler no longer reads the locale, `WeekFields`, or the display preference at all.

P.S. studying CLDR and user's preferences is such a pain in the arse. I spent a good hour researching and mostly reading up on "[Davydenko, Mariya & Peetz, Johanna. (2019). Does it matter if a week starts on Monday or Sunday?: How calendar format can boost goal motivation. Journal of Experimental Social Psychology. 82. 231-237. 10.1016/j.jesp.2019.02.005.](https://www.researchgate.net/publication/331357590_Does_it_matter_if_a_week_starts_on_Monday_or_Sunday_How_calendar_format_can_boost_goal_motivation)"