### PR TITLE
Fix alarm filtering and keep filters visible above results

### DIFF
--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/AlarmScreen.kt
@@ -1,5 +1,6 @@
 package com.bnyro.clock.presentation.screens.alarm
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
@@ -9,7 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -170,72 +170,74 @@ fun AlarmScreen(
             }
         }) { pv ->
 
-        if (alarms.isEmpty()) {
-            BlobIconBox(icon = R.drawable.ic_alarm)
-        }
-        LazyColumn(
+        Column(
             Modifier
                 .fillMaxSize()
                 .padding(pv)
         ) {
-            item {
-                if (alarmModel.showFilter) {
-                    AlarmFilterSection(
-                        filters,
-                        { alarmModel.updateLabelFilter(it) },
-                        { alarmModel.updateWeekDayFilter(it) },
-                        { alarmModel.updateStartTimeFilter(it) },
-                        { alarmModel.updateEndTimeFilter(it) },
-                    )
-                }
-            }
-
-            items(
-                items = alarms,
-                key = { it.id.toString() + "-" + it.enabled }
-            ) { alarm ->
-                val isSelected = selectedAlarmIds.contains(alarm.id)
-
-                AlarmItem(
-                    alarm = alarm,
-                    isSelected = isSelected,
-                    isSelectionMode = isSelectionMode,
-                    onLongClick = { alarmItem ->
-                        if (!isSelectionMode) {
-                            selectedAlarmIds.add(alarmItem.id)
-                        }
-                    },
-                    onClick = { alarmItem ->
-                        if (isSelectionMode) {
-                            if (isSelected) {
-                                selectedAlarmIds.remove(alarmItem.id)
-                            } else {
-                                selectedAlarmIds.add(alarmItem.id)
-                            }
-                        } else {
-                            onAlarm.invoke(alarmItem.id, alarmItem.advanced)
-                        }
-                    },
-                    onDeleteAlarm = { alarmItem ->
-                        alarmModel.deleteAlarm(alarmItem)
-                    },
-                    onDismissAlarm = { alarmItem ->
-                        alarmModel.dismissUpcomingAlarm(alarmItem)
-                    },
-                    onUpdateAlarm = { updatedAlarm ->
-                        if (!isSelectionMode) {
-                            alarmModel.updateAlarm(updatedAlarm)
-
-                            if (updatedAlarm.enabled) {
-                                AlarmHelper.showAlarmScheduledToast(context, updatedAlarm)
-                            }
-                        }
-                    }
+            if (alarmModel.showFilter) {
+                AlarmFilterSection(
+                    filters,
+                    { alarmModel.updateLabelFilter(it) },
+                    { alarmModel.updateWeekDayFilter(it) },
+                    { alarmModel.updateStartTimeFilter(it) },
+                    { alarmModel.updateEndTimeFilter(it) },
                 )
             }
 
-            item {
-                Spacer(modifier = Modifier.height(80.dp))
+            Box(Modifier.weight(1f)) {
+                if (alarms.isEmpty()) {
+                    BlobIconBox(icon = R.drawable.ic_alarm)
+                }
+                LazyColumn(Modifier.fillMaxSize()) {
+                    items(
+                        items = alarms,
+                        key = { it.id.toString() + "-" + it.enabled }
+                    ) { alarm ->
+                        val isSelected = selectedAlarmIds.contains(alarm.id)
+
+                        AlarmItem(
+                            alarm = alarm,
+                            isSelected = isSelected,
+                            isSelectionMode = isSelectionMode,
+                            onLongClick = { alarmItem ->
+                                if (!isSelectionMode) {
+                                    selectedAlarmIds.add(alarmItem.id)
+                                }
+                            },
+                            onClick = { alarmItem ->
+                                if (isSelectionMode) {
+                                    if (isSelected) {
+                                        selectedAlarmIds.remove(alarmItem.id)
+                                    } else {
+                                        selectedAlarmIds.add(alarmItem.id)
+                                    }
+                                } else {
+                                    onAlarm.invoke(alarmItem.id, alarmItem.advanced)
+                                }
+                            },
+                            onDeleteAlarm = { alarmItem ->
+                                alarmModel.deleteAlarm(alarmItem)
+                            },
+                            onDismissAlarm = { alarmItem ->
+                                alarmModel.dismissUpcomingAlarm(alarmItem)
+                            },
+                            onUpdateAlarm = { updatedAlarm ->
+                                if (!isSelectionMode) {
+                                    alarmModel.updateAlarm(updatedAlarm)
+
+                                    if (updatedAlarm.enabled) {
+                                        AlarmHelper.showAlarmScheduledToast(context, updatedAlarm)
+                                    }
+                                }
+                            }
+                        )
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(80.dp))
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/model/AlarmModel.kt
+++ b/app/src/main/java/com/bnyro/clock/presentation/screens/alarm/model/AlarmModel.kt
@@ -37,9 +37,9 @@ class AlarmModel(application: Application) : AndroidViewModel(application) {
             val filtered = items.filter { alarm ->
                 (filter.startTime <= alarm.time && alarm.time <= filter.endTime)
                         && !Collections.disjoint(filter.weekDays, alarm.days)
-                        && (alarm.label?.lowercase()?.contains(filter.label.lowercase())
-                    ?: true) && (TimeHelper.millisToFormatted(getApplication(), alarm.time).lowercase()
-                    .contains(filter.label.lowercase()))
+                        && (alarm.label.orEmpty().contains(filter.label, ignoreCase = true)
+                        || TimeHelper.millisToFormatted(getApplication(), alarm.time)
+                            .contains(filter.label, ignoreCase = true))
 
             }
 


### PR DESCRIPTION
Alarm search currently requires the query to match both the label and the formatted time. An alarm named “Work” at 07:00 therefore disappears when searching for “Work”. Match either field case-insensitively while preserving weekday and time-range constraints.

Move the filter controls above the scrollable alarm list so they remain visible when opened at any scroll position without covering alarms. Display the empty-results icon in the remaining space below the filters.